### PR TITLE
Rebuild F3: listings + about/CV page

### DIFF
--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -1,0 +1,99 @@
+import type { Metadata } from 'next';
+import { CertificationTile, EducationEntry, PositionEntry } from '@/components/cv';
+import { getAbout, getSiteConfig } from '@/lib/api';
+import { renderMarkdown } from '@/lib/markdown';
+import '@/styles/about.css';
+
+export async function generateMetadata(): Promise<Metadata> {
+  const about = await getAbout();
+  return {
+    title: about.seoTitle ?? `About — ${about.fullName}`,
+    description: about.seoDescription ?? undefined,
+  };
+}
+
+function initials(fullName: string): string {
+  return fullName
+    .split(/\s+/)
+    .filter(Boolean)
+    .slice(0, 2)
+    .map((part) => part[0].toLowerCase())
+    .join('');
+}
+
+export default async function AboutPage() {
+  const [about, config] = await Promise.all([getAbout(), getSiteConfig()]);
+  const profile = await renderMarkdown(about.profileMd);
+  const firstName = about.fullName.split(/\s+/)[0];
+
+  return (
+    <>
+      <div className="about-head">
+        <span className="avatar">
+          {about.avatarUrl ? (
+            <img src={about.avatarUrl} alt={about.fullName} />
+          ) : (
+            initials(about.fullName)
+          )}
+        </span>
+        <div className="about-intro">
+          <h1 className="about-h1">Hi, I&apos;m {firstName}.</h1>
+          <div className="about-lede" dangerouslySetInnerHTML={{ __html: profile.html }} />
+        </div>
+      </div>
+
+      <div className="contact-line">
+        <span className="contact-muted">{about.location}</span>
+        <span className="sep">|</span>
+        <a href={`mailto:${about.contactEmail}`}>Email</a>
+        {config.socialLinks.map((link) => (
+          <span key={link.url} className="contact-social">
+            <span className="sep">|</span>
+            <a href={link.url} rel="me noopener" target="_blank">
+              {link.label.charAt(0).toUpperCase() + link.label.slice(1)}
+            </a>
+          </span>
+        ))}
+      </div>
+
+      {about.positions.length > 0 && (
+        <>
+          <div className="section-head">
+            <h2>Work history</h2>
+          </div>
+          <div className="timeline">
+            {about.positions.map((position) => (
+              <PositionEntry key={position.id} position={position} />
+            ))}
+          </div>
+        </>
+      )}
+
+      {about.education.length > 0 && (
+        <>
+          <div className="section-head">
+            <h2>Education</h2>
+          </div>
+          <div className="timeline">
+            {about.education.map((entry) => (
+              <EducationEntry key={entry.id} entry={entry} />
+            ))}
+          </div>
+        </>
+      )}
+
+      {about.certifications.length > 0 && (
+        <>
+          <div className="section-head">
+            <h2>Certifications</h2>
+          </div>
+          <div className="cert-grid">
+            {about.certifications.map((cert) => (
+              <CertificationTile key={cert.id} cert={cert} />
+            ))}
+          </div>
+        </>
+      )}
+    </>
+  );
+}

--- a/src/app/blog/page.tsx
+++ b/src/app/blog/page.tsx
@@ -1,0 +1,17 @@
+import type { Metadata } from 'next';
+import { Listing, parseListingParams } from '@/components/listing';
+
+export const metadata: Metadata = {
+  title: 'Blog',
+  description:
+    'Security engineering write-ups: detection engineering, cloud security, incident notes.',
+};
+
+interface Props {
+  searchParams: Promise<{ page?: string; per?: string }>;
+}
+
+export default async function BlogPage({ searchParams }: Props) {
+  const { page, per } = parseListingParams(await searchParams);
+  return <Listing type="article" title="Blog" basePath="/blog" page={page} per={per} />;
+}

--- a/src/app/projects/page.tsx
+++ b/src/app/projects/page.tsx
@@ -1,0 +1,16 @@
+import type { Metadata } from 'next';
+import { Listing, parseListingParams } from '@/components/listing';
+
+export const metadata: Metadata = {
+  title: 'Projects',
+  description: 'Security tooling and infrastructure projects.',
+};
+
+interface Props {
+  searchParams: Promise<{ page?: string; per?: string }>;
+}
+
+export default async function ProjectsPage({ searchParams }: Props) {
+  const { page, per } = parseListingParams(await searchParams);
+  return <Listing type="project" title="Projects" basePath="/projects" page={page} per={per} />;
+}

--- a/src/components/cv.tsx
+++ b/src/components/cv.tsx
@@ -1,0 +1,159 @@
+import type { ReactNode } from 'react';
+import { fmtMonthYear, fmtYear, fmtYearMonth } from '@/lib/format';
+import type { CvCertification, CvEducation, CvPosition } from '@/lib/types';
+
+/** Bullets like "Detection engineering: built …" get their label bolded, per the mockup. */
+function Bullet({ text }: { text: string }) {
+  const match = /^([^:]{2,60}):\s+(.*)$/s.exec(text);
+  if (!match) {
+    return <li>{text}</li>;
+  }
+  return (
+    <li>
+      <strong>{match[1]}:</strong> {match[2]}
+    </li>
+  );
+}
+
+function LogoBox({
+  logoUrl,
+  alt,
+  className,
+  fallback,
+}: {
+  logoUrl: string | null;
+  alt: string;
+  className: string;
+  fallback: ReactNode;
+}) {
+  return (
+    <span className={className}>
+      {logoUrl ? <img src={logoUrl} alt={alt} loading="lazy" /> : fallback}
+    </span>
+  );
+}
+
+const GradCapIcon = (
+  <svg
+    width="15"
+    height="15"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="2"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    aria-hidden="true"
+  >
+    <path d="M22 10L12 5 2 10l10 5 10-5z" />
+    <path d="M6 12v5c0 1.7 2.7 3 6 3s6-1.3 6-3v-5" />
+  </svg>
+);
+
+export function PositionEntry({ position }: { position: CvPosition }) {
+  const range = `${fmtMonthYear(position.startDate)} — ${
+    position.endDate ? fmtMonthYear(position.endDate) : 'Present'
+  }`;
+
+  return (
+    <div className="timeline-entry">
+      <div className="timeline-icon-col">
+        <LogoBox
+          logoUrl={position.logoUrl}
+          alt={position.company}
+          className="logo-box"
+          fallback="logo"
+        />
+        <span className="connector" />
+      </div>
+      <div className="timeline-body">
+        <div className="entry-head">
+          <span className="role-line">
+            {position.title} ·{' '}
+            {position.companyUrl ? (
+              <a href={position.companyUrl} rel="noopener" target="_blank">
+                {position.company} ↗
+              </a>
+            ) : (
+              position.company
+            )}
+          </span>
+          <span className="entry-meta">
+            {position.location} · {range}
+          </span>
+        </div>
+        {position.description && <p className="role-blurb">{position.description}</p>}
+        {position.bullets.length > 0 && (
+          <ul className="entry-bullets">
+            {position.bullets.map((bullet) => (
+              <Bullet key={bullet} text={bullet} />
+            ))}
+          </ul>
+        )}
+        {position.skills.length > 0 && (
+          <div className="tag-row skill-row">
+            {position.skills.map((skill) => (
+              <span key={skill} className="tag">
+                {skill}
+              </span>
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export function EducationEntry({ entry }: { entry: CvEducation }) {
+  const range = `${fmtYear(entry.startDate)} — ${entry.endDate ? fmtYear(entry.endDate) : 'Present'}`;
+
+  return (
+    <div className="timeline-entry education">
+      <div className="timeline-icon-col">
+        <LogoBox
+          logoUrl={entry.logoUrl}
+          alt={entry.institution}
+          className="logo-box edu-box"
+          fallback={GradCapIcon}
+        />
+        <span className="connector" />
+      </div>
+      <div className="timeline-body">
+        <div className="entry-head">
+          <span className="degree-line">
+            {entry.degree} {entry.field} · {entry.institution}
+          </span>
+          <span className="entry-meta">
+            {entry.location} · {range}
+          </span>
+        </div>
+        {entry.notes && <p className="edu-notes">{entry.notes}</p>}
+      </div>
+    </div>
+  );
+}
+
+export function CertificationTile({ cert }: { cert: CvCertification }) {
+  const expiry = cert.expiresDate ? `Expires ${fmtYearMonth(cert.expiresDate)}` : 'No expiration';
+
+  return (
+    <div className="cert-tile">
+      <div className="cert-head">
+        <LogoBox logoUrl={cert.logoUrl} alt={cert.issuer} className="cert-icon" fallback="cert" />
+        <span className="cert-name">
+          {cert.credentialUrl ? (
+            <a href={cert.credentialUrl} rel="noopener" target="_blank">
+              {cert.name}
+            </a>
+          ) : (
+            cert.name
+          )}
+        </span>
+      </div>
+      {cert.description && <p className="cert-desc">{cert.description}</p>}
+      <span className="cert-foot">
+        Issued {fmtYearMonth(cert.issuedDate)} · {expiry}
+      </span>
+    </div>
+  );
+}

--- a/src/components/listing.tsx
+++ b/src/components/listing.tsx
@@ -1,0 +1,52 @@
+import { EmptyState } from '@/components/empty-state';
+import { Pagination } from '@/components/pagination';
+import { PostRow } from '@/components/post-row';
+import { getPosts } from '@/lib/api';
+import { PER_PAGE_OPTIONS } from '@/lib/format';
+import type { PostType } from '@/lib/types';
+
+/**
+ * ?page=&per= come from the address bar, so anything malformed simply falls
+ * back to defaults instead of erroring.
+ */
+export function parseListingParams(params: { page?: string; per?: string }): {
+  page: number;
+  per: number;
+} {
+  const page = Number(params.page);
+  const per = Number(params.per);
+  return {
+    page: Number.isInteger(page) && page >= 1 ? page : 1,
+    per: (PER_PAGE_OPTIONS as readonly number[]).includes(per) ? per : 10,
+  };
+}
+
+interface Props {
+  type: PostType;
+  title: string;
+  basePath: string;
+  page: number;
+  per: number;
+}
+
+export async function Listing({ type, title, basePath, page, per }: Props) {
+  const list = await getPosts(type, page, per);
+
+  return (
+    <>
+      <h1 className="page-title">{title}</h1>
+      {list.total === 0 ? (
+        <EmptyState>Nothing here yet.</EmptyState>
+      ) : (
+        <>
+          <div className="post-list listing">
+            {list.items.map((post) => (
+              <PostRow key={post.slug} post={post} />
+            ))}
+          </div>
+          <Pagination basePath={basePath} total={list.total} page={page} per={per} />
+        </>
+      )}
+    </>
+  );
+}

--- a/src/components/pagination.tsx
+++ b/src/components/pagination.tsx
@@ -1,0 +1,110 @@
+'use client';
+
+import Link from 'next/link';
+import { useRouter } from 'next/navigation';
+import { PER_PAGE_OPTIONS } from '@/lib/format';
+
+/** 1 … around-current … last, per the mockup's pagination bar. */
+function pageNumbers(totalPages: number, current: number): (number | '…')[] {
+  if (totalPages <= 7) {
+    return Array.from({ length: totalPages }, (_, i) => i + 1);
+  }
+  const wanted = new Set([1, totalPages, current - 1, current, current + 1]);
+  const pages: (number | '…')[] = [];
+  let previous = 0;
+  for (let n = 1; n <= totalPages; n += 1) {
+    if (!wanted.has(n)) {
+      continue;
+    }
+    if (n - previous > 1) {
+      pages.push('…');
+    }
+    pages.push(n);
+    previous = n;
+  }
+  return pages;
+}
+
+interface Props {
+  basePath: string;
+  total: number;
+  page: number;
+  per: number;
+}
+
+export function Pagination({ basePath, total, page, per }: Props) {
+  const router = useRouter();
+  const totalPages = Math.max(1, Math.ceil(total / per));
+  const href = (p: number, perValue = per) => `${basePath}?page=${p}&per=${perValue}`;
+
+  return (
+    <div className="pagination">
+      <label className="per-select">
+        <span>per page</span>
+        <span className="per-chip">
+          <select
+            value={per}
+            aria-label="Results per page"
+            onChange={(event) => router.push(href(1, Number(event.target.value)))}
+          >
+            {PER_PAGE_OPTIONS.map((option) => (
+              <option key={option} value={option}>
+                {option}
+              </option>
+            ))}
+          </select>
+          <svg
+            width="9"
+            height="9"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="3"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            aria-hidden="true"
+          >
+            <path d="M6 9l6 6 6-6" />
+          </svg>
+        </span>
+      </label>
+
+      <nav className="page-nav" aria-label="Pagination">
+        {page > 1 ? (
+          <Link className="page-btn" href={href(page - 1)} aria-label="Previous page">
+            ‹
+          </Link>
+        ) : (
+          <span className="page-btn disabled" aria-hidden="true">
+            ‹
+          </span>
+        )}
+        {pageNumbers(totalPages, page).map((n, i) =>
+          n === '…' ? (
+            <span key={`gap-${i}`} className="page-ellipsis">
+              …
+            </span>
+          ) : (
+            <Link
+              key={n}
+              className={n === page ? 'page-btn active' : 'page-btn'}
+              href={href(n)}
+              aria-current={n === page ? 'page' : undefined}
+            >
+              {n}
+            </Link>
+          ),
+        )}
+        {page < totalPages ? (
+          <Link className="page-btn" href={href(page + 1)} aria-label="Next page">
+            ›
+          </Link>
+        ) : (
+          <span className="page-btn disabled" aria-hidden="true">
+            ›
+          </span>
+        )}
+      </nav>
+    </div>
+  );
+}

--- a/src/lib/format.ts
+++ b/src/lib/format.ts
@@ -1,3 +1,5 @@
+export const PER_PAGE_OPTIONS = [10, 25, 50] as const;
+
 /** '2026-07-14T09:00:00Z' -> '2026-07-14'. Published content must have a date. */
 export function fmtDate(iso: string | null): string {
   if (!iso) {

--- a/src/styles/about.css
+++ b/src/styles/about.css
@@ -1,0 +1,353 @@
+/* About / CV page (mockup screen 4c). */
+
+.about-head {
+  margin-top: 52px;
+  display: flex;
+  gap: 28px;
+  align-items: flex-start;
+  flex-wrap: wrap;
+}
+
+.avatar {
+  width: 96px;
+  height: 96px;
+  border-radius: 8px;
+  background: var(--chip);
+  border: 1px solid var(--border);
+  display: grid;
+  place-items: center;
+  font-family: var(--font-mono);
+  font-size: 24px;
+  font-weight: 700;
+  color: var(--muted);
+  overflow: hidden;
+  flex: none;
+}
+
+.avatar img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.about-intro {
+  flex: 1;
+  min-width: 300px;
+}
+
+.about-h1 {
+  font-family: var(--font-serif);
+  font-size: 28px;
+  font-weight: 600;
+  line-height: 1.3;
+  color: var(--text);
+}
+
+.about-lede {
+  margin-top: 14px;
+  font-family: var(--font-serif);
+  font-size: 16px;
+  line-height: 1.75;
+  color: var(--body);
+}
+
+.about-lede a {
+  color: var(--text);
+  text-decoration: underline;
+  text-decoration-color: var(--link-tint);
+  text-underline-offset: 3px;
+}
+
+.contact-line {
+  margin-top: 24px;
+  display: flex;
+  align-items: baseline;
+  flex-wrap: wrap;
+  gap: 14px;
+  font-family: var(--font-mono);
+  font-size: 12.5px;
+}
+
+.contact-muted {
+  color: var(--muted);
+}
+
+.contact-line .sep {
+  color: var(--faint);
+}
+
+.contact-social {
+  display: inline-flex;
+  gap: 14px;
+}
+
+.contact-line a {
+  color: var(--text);
+  text-decoration: underline;
+  text-decoration-color: var(--link-tint);
+  text-underline-offset: 3px;
+}
+
+.contact-line a:hover {
+  text-decoration-thickness: 2px;
+}
+
+/* --- Sections ---------------------------------------------------------------- */
+
+.section-head {
+  margin-top: 44px;
+  border-bottom: 1px solid var(--border);
+  padding-bottom: 10px;
+}
+
+.section-head h2 {
+  font-family: var(--font-sans);
+  font-size: 15px;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--secondary);
+}
+
+/* --- Timelines --------------------------------------------------------------- */
+
+.timeline {
+  margin-top: 28px;
+}
+
+.timeline-entry {
+  display: grid;
+  grid-template-columns: 44px 1fr;
+  gap: 0 22px;
+}
+
+.timeline-icon-col {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 8px;
+}
+
+.logo-box {
+  width: 44px;
+  height: 44px;
+  border-radius: 8px;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  display: grid;
+  place-items: center;
+  font-family: var(--font-mono);
+  font-size: 10px;
+  color: var(--muted);
+  overflow: hidden;
+  flex: none;
+}
+
+.logo-box img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.edu-box {
+  width: 32px;
+  height: 32px;
+  border-radius: 6px;
+}
+
+.connector {
+  width: 2px;
+  flex: 1;
+  background: var(--border);
+  min-height: 24px;
+}
+
+.timeline-entry:last-child .connector {
+  display: none;
+}
+
+.timeline-body {
+  padding-bottom: 36px;
+  min-width: 0;
+}
+
+.timeline-entry:last-child .timeline-body {
+  padding-bottom: 0;
+}
+
+.timeline-entry.education .timeline-body {
+  padding-bottom: 28px;
+}
+
+.timeline-entry.education:last-child .timeline-body {
+  padding-bottom: 0;
+}
+
+.entry-head {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  flex-wrap: wrap;
+  gap: 4px 16px;
+}
+
+.role-line {
+  font-family: var(--font-sans);
+  font-size: 15.5px;
+  font-weight: 600;
+  color: var(--text);
+}
+
+.degree-line {
+  font-family: var(--font-sans);
+  font-size: 14.5px;
+  font-weight: 600;
+  color: var(--text);
+}
+
+.role-line a {
+  color: inherit;
+  text-decoration: underline;
+  text-decoration-color: var(--link-tint);
+  text-underline-offset: 3px;
+}
+
+.role-line a:hover {
+  text-decoration-color: var(--text);
+}
+
+.entry-meta {
+  font-family: var(--font-mono);
+  font-size: 11.5px;
+  color: var(--muted);
+  flex: none;
+}
+
+.role-blurb {
+  margin-top: 5px;
+  font-family: var(--font-sans);
+  font-size: 13px;
+  line-height: 1.6;
+  color: var(--muted);
+}
+
+.edu-notes {
+  margin-top: 8px;
+  font-family: var(--font-sans);
+  font-size: 13px;
+  line-height: 1.6;
+  color: var(--secondary);
+}
+
+.entry-bullets {
+  margin-top: 12px;
+  padding-left: 20px;
+}
+
+.entry-bullets li {
+  font-family: var(--font-sans);
+  font-size: 13.5px;
+  line-height: 1.65;
+  color: var(--body);
+}
+
+.entry-bullets li + li {
+  margin-top: 8px;
+}
+
+.entry-bullets strong {
+  font-weight: 600;
+  color: var(--text);
+}
+
+.skill-row {
+  margin-top: 14px;
+}
+
+/* --- Certifications ----------------------------------------------------------- */
+
+.cert-grid {
+  margin-top: 24px;
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 16px;
+}
+
+@media (max-width: 560px) {
+  .cert-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .about-head {
+    margin-top: 40px;
+  }
+}
+
+.cert-tile {
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: var(--surface);
+  padding: 18px 20px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.cert-head {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.cert-icon {
+  width: 36px;
+  height: 36px;
+  border-radius: 6px;
+  background: var(--chip);
+  border: 1px solid var(--border);
+  display: grid;
+  place-items: center;
+  font-family: var(--font-mono);
+  font-size: 9px;
+  color: var(--muted);
+  overflow: hidden;
+  flex: none;
+}
+
+.cert-icon img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.cert-name {
+  font-family: var(--font-sans);
+  font-size: 14px;
+  font-weight: 600;
+  line-height: 1.3;
+  color: var(--text);
+}
+
+.cert-name a {
+  color: inherit;
+  text-decoration: underline;
+  text-decoration-color: var(--link-tint);
+  text-underline-offset: 3px;
+}
+
+.cert-name a:hover {
+  text-decoration-color: var(--text);
+}
+
+.cert-desc {
+  font-family: var(--font-sans);
+  font-size: 12.5px;
+  line-height: 1.6;
+  color: var(--secondary);
+}
+
+.cert-foot {
+  font-family: var(--font-mono);
+  font-size: 10.5px;
+  color: var(--muted);
+}

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -343,6 +343,101 @@ h3 {
   color: var(--text);
 }
 
+/* --- Listing pagination ------------------------------------------------------ */
+
+.listing {
+  margin-top: 28px;
+}
+
+.pagination {
+  margin-top: 36px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 12px;
+  font-family: var(--font-mono);
+  font-size: 11.5px;
+  color: var(--muted);
+}
+
+.per-select {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.per-chip {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  background: var(--surface);
+  padding: 5px 10px;
+  color: var(--text);
+}
+
+.per-chip:hover {
+  border-color: var(--link-tint);
+}
+
+.per-chip select {
+  appearance: none;
+  border: none;
+  background: none;
+  color: inherit;
+  font: inherit;
+  cursor: pointer;
+  padding-right: 2px;
+}
+
+.per-chip select:focus {
+  outline: none;
+}
+
+.page-nav {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.page-btn {
+  width: 28px;
+  height: 28px;
+  display: inline-grid;
+  place-items: center;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  background: var(--surface);
+  color: var(--text);
+  text-decoration: none;
+  font-family: var(--font-mono);
+  font-size: 11.5px;
+}
+
+.page-btn:hover {
+  border-color: var(--link-tint);
+}
+
+.page-btn.active {
+  background: var(--text);
+  color: var(--bg);
+  border-color: var(--text);
+}
+
+.page-btn.disabled {
+  color: var(--faint);
+  pointer-events: none;
+}
+
+.page-ellipsis {
+  color: var(--faint);
+  width: 20px;
+  text-align: center;
+}
+
 @media (max-width: 560px) {
   .shell {
     padding: 32px 20px 48px;


### PR DESCRIPTION
Third frontend milestone, stacked on #80.

## Listings (`/blog`, `/projects`)
One shared `Listing` per the mockup's listing screen: H1, list rows (same anatomy as home), pagination bar — `per page` select chip (10/25/50, chevron) left, prev/next + numbered 28×28 buttons with active inversion and ellipsis right. State lives in `?page=&per=`; malformed query values fall back to defaults (address-bar input, not trusted data); empty DB renders the empty-state box.

## About (`/about`)
Mockup 4c: 96px avatar (initials fallback), "Hi, I'm Mikhail." serif heading, markdown-rendered profile, mono contact line (location | Email | GitHub | LinkedIn), WORK HISTORY timeline (44px logo column, 2px connector stopping at the last entry, role blurbs, **bolded bullet labels**, skill chips, `Company ↗` links), EDUCATION timeline (32px grad-cap icon boxes, thesis note), CERTIFICATIONS 2-col tiles (`Issued … · Expires …` / `No expiration`, names link to credentials).

## Notes
- Fixed an RSC pitfall: a constant exported from a `'use client'` module resolves to a client-reference proxy in server components — moved to a shared plain module.
- Seed profile no longer duplicates the greeting the template renders (small API-repo commit).

## Verified
Both pages **visually checked in Chrome against the mockup**; pagination exercised via `?page=&per=`. Typecheck + `next build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)