### PR TITLE
Rebuild F5: SEO + RSS + revalidation + Docker + CI

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,11 @@
+node_modules
+.next
+.git
+.github
+.claude
+.env
+.env.*
+!.env.example
+CLAUDE.md
+README.md
+*.log

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,88 @@
+name: build-and-deploy
+
+on:
+  push:
+    branches: [master]
+  workflow_dispatch:
+
+concurrency:
+  group: deploy-front
+  cancel-in-progress: false
+
+env:
+  IMAGE: ghcr.io/${{ github.repository_owner }}/personal-blog-front
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+      - run: npm ci
+      - run: npm run typecheck
+      - run: npm test
+
+  build:
+    needs: test
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker/setup-buildx-action@v3
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          build-args: |
+            NEXT_PUBLIC_SITE_URL=${{ secrets.NEXT_PUBLIC_SITE_URL }}
+            NEXT_PUBLIC_API_URL=${{ secrets.NEXT_PUBLIC_API_URL }}
+          tags: |
+            ${{ env.IMAGE }}:${{ github.sha }}
+            ${{ env.IMAGE }}:latest
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ secrets.AWS_REGION }}
+      - name: Resolve runner IP
+        id: ip
+        run: echo "ip=$(curl -s https://checkip.amazonaws.com)" >> "$GITHUB_OUTPUT"
+      - name: Open SSH to runner IP
+        run: |
+          aws ec2 authorize-security-group-ingress \
+            --group-id "${{ secrets.EC2_SG_ID }}" \
+            --protocol tcp --port 22 \
+            --cidr "${{ steps.ip.outputs.ip }}/32"
+      - name: Deploy
+        run: |
+          install -m 700 -d ~/.ssh
+          echo "${{ secrets.EC2_SSH_KEY }}" > ~/.ssh/deploy_key
+          chmod 600 ~/.ssh/deploy_key
+          echo "${{ secrets.EC2_SSH_HOST_KEY }}" > ~/.ssh/known_hosts
+          ssh -i ~/.ssh/deploy_key -o StrictHostKeyChecking=yes \
+            "${{ secrets.EC2_SSH_USER }}@${{ secrets.EC2_HOST }}" \
+            'cd /opt/blog && docker compose pull front && docker compose up -d front && docker image prune -f'
+      - name: Revoke SSH access
+        if: always()
+        run: |
+          aws ec2 revoke-security-group-ingress \
+            --group-id "${{ secrets.EC2_SG_ID }}" \
+            --protocol tcp --port 22 \
+            --cidr "${{ steps.ip.outputs.ip }}/32"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,36 @@
+# --- deps ---------------------------------------------------------------------
+FROM node:22-slim AS deps
+WORKDIR /app
+COPY package.json package-lock.json ./
+RUN npm ci
+
+# --- build --------------------------------------------------------------------
+FROM deps AS build
+COPY . .
+# NEXT_PUBLIC_* are inlined at build time. Provide the production public URLs.
+ARG NEXT_PUBLIC_SITE_URL
+ARG NEXT_PUBLIC_API_URL
+ENV NEXT_PUBLIC_SITE_URL=$NEXT_PUBLIC_SITE_URL
+ENV NEXT_PUBLIC_API_URL=$NEXT_PUBLIC_API_URL
+RUN npm run build
+
+# --- runtime (standalone output) ----------------------------------------------
+FROM node:22-slim AS runtime
+WORKDIR /app
+ENV NODE_ENV=production
+ENV PORT=3000
+ENV HOSTNAME=0.0.0.0
+
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends curl \
+  && rm -rf /var/lib/apt/lists/*
+
+COPY --from=build /app/.next/standalone ./
+COPY --from=build /app/.next/static ./.next/static
+COPY --from=build /app/public ./public
+
+USER node
+EXPOSE 3000
+HEALTHCHECK --interval=30s --timeout=5s --start-period=15s \
+  CMD curl -fsS http://localhost:3000/ || exit 1
+CMD ["node", "server.js"]

--- a/README.md
+++ b/README.md
@@ -2,7 +2,18 @@
 
 Public blog for [mikhailbahdashych.me](https://mikhailbahdashych.me) — Next.js (App Router, SSR).
 
-> Rebuild in progress. Full documentation lands with the final shipping PR.
+Part of a three-repo system: **personal-blog-front** (this), `personal-blog-api` (content API), `personal-blog-admin` (editor).
+
+## Architecture
+
+- **App Router, dynamic rendering + tag-cached data.** Every route renders on request; API reads go through Next's data cache keyed by tags (`posts`, `post:<slug>`, `about`, `config`). The API invalidates those tags via `POST /api/revalidate` after each admin mutation, with a 1-hour staleness fallback. Builds never require a running API.
+- **Markdown** (`src/lib/markdown.ts`): unified/remark/rehype — GFM, KaTeX math, Shiki highlighting, figures + table captions + TOC. Runs server-side only.
+- **Theme**: `data-theme` on `<html>`, persisted in localStorage, system default, set by an inline pre-paint script (no flash).
+- **SEO**: server-rendered metadata (canonical, Open Graph, Twitter), JSON-LD (`BlogPosting`/`CreativeWork`), `sitemap.xml`, `robots.txt`, `rss.xml`, proper 404 status.
+
+## Pages
+
+`/` home · `/blog` + `/projects` listings (pagination) · `/blog/[slug]` + `/projects/[slug]` detail · `/about` CV · `/search` results · 404.
 
 ## Development
 
@@ -13,3 +24,23 @@ cp .env.example .env.local
 npm install
 npm run dev            # http://localhost:3000
 ```
+
+| Script | Purpose |
+| --- | --- |
+| `npm run build` / `start` | Production build (standalone) / serve |
+| `npm run typecheck` | `tsc --noEmit` |
+| `npm test` | Vitest — markdown pipeline fixtures |
+| `npm run format` | Prettier |
+
+## Environment
+
+| Var | Purpose |
+| --- | --- |
+| `API_INTERNAL_URL` | Server-side API base (container-internal in prod) |
+| `NEXT_PUBLIC_SITE_URL` | Canonical site origin (build-time inlined) |
+| `NEXT_PUBLIC_API_URL` | Browser-facing API base for search (build-time inlined) |
+| `REVALIDATE_SECRET` | Shared secret guarding `/api/revalidate` (matches the API) |
+
+## Deployment
+
+Multi-stage Docker image (standalone output) built by `.github/workflows/deploy.yml` → GHCR → SSH deploy into the EC2 compose stack. Infra lives in the API repo's [`deploy/`](https://github.com/mikhailbahdashych/personal-blog-api/tree/master/deploy).

--- a/src/app/api/revalidate/route.ts
+++ b/src/app/api/revalidate/route.ts
@@ -1,0 +1,42 @@
+import { revalidateTag } from 'next/cache';
+import { NextRequest, NextResponse } from 'next/server';
+import { requireEnv } from '@/lib/env';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+/**
+ * Called by the API after admin mutations to invalidate the affected cache
+ * tags. Guarded by a shared secret (constant-time compared).
+ */
+export async function POST(request: NextRequest) {
+  let body: { secret?: unknown; tags?: unknown };
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON' }, { status: 400 });
+  }
+
+  if (typeof body.secret !== 'string' || !safeEqual(body.secret, requireEnv('REVALIDATE_SECRET'))) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+  if (!Array.isArray(body.tags) || !body.tags.every((tag) => typeof tag === 'string')) {
+    return NextResponse.json({ error: 'tags must be a string array' }, { status: 400 });
+  }
+
+  for (const tag of body.tags as string[]) {
+    revalidateTag(tag);
+  }
+  return NextResponse.json({ revalidated: body.tags });
+}
+
+function safeEqual(a: string, b: string): boolean {
+  if (a.length !== b.length) {
+    return false;
+  }
+  let diff = 0;
+  for (let i = 0; i < a.length; i += 1) {
+    diff |= a.charCodeAt(i) ^ b.charCodeAt(i);
+  }
+  return diff === 0;
+}

--- a/src/app/blog/[slug]/page.tsx
+++ b/src/app/blog/[slug]/page.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from 'next';
 import { notFound } from 'next/navigation';
 import { PostDetail } from '@/components/post-detail';
 import { getPost } from '@/lib/api';
+import { postMetadata } from '@/lib/seo';
 import 'katex/dist/katex.min.css';
 import '@/styles/prose.css';
 
@@ -12,10 +13,7 @@ interface Props {
 export async function generateMetadata({ params }: Props): Promise<Metadata> {
   const { slug } = await params;
   const post = await getPost(slug);
-  return {
-    title: post.seoTitle ?? post.title,
-    description: post.seoDescription ?? post.excerpt,
-  };
+  return postMetadata(post);
 }
 
 export default async function BlogPostPage({ params }: Props) {

--- a/src/app/icon.svg
+++ b/src/app/icon.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <rect width="32" height="32" rx="6" fill="#1c1c1a" />
+  <text x="16" y="22" font-family="'JetBrains Mono', monospace" font-size="16" font-weight="700" fill="#fbfaf7" text-anchor="middle">mb</text>
+</svg>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -4,6 +4,7 @@ import type { ReactNode } from 'react';
 import { Footer } from '@/components/footer';
 import { Header } from '@/components/header';
 import { getSiteConfig } from '@/lib/api';
+import { baseMetadata } from '@/lib/seo';
 import '@/styles/globals.css';
 
 // Every route renders on request; data comes from Next's tag-invalidated fetch
@@ -39,13 +40,7 @@ const THEME_SCRIPT = `(function(){var t;try{t=localStorage.getItem('theme')}catc
 
 export async function generateMetadata(): Promise<Metadata> {
   const config = await getSiteConfig();
-  return {
-    title: {
-      default: config.seoDefaultTitle,
-      template: '%s · Mikhail Bahdashych',
-    },
-    description: config.seoDefaultDescription,
-  };
+  return baseMetadata(config);
 }
 
 export default async function RootLayout({ children }: { children: ReactNode }) {

--- a/src/app/projects/[slug]/page.tsx
+++ b/src/app/projects/[slug]/page.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from 'next';
 import { notFound } from 'next/navigation';
 import { PostDetail } from '@/components/post-detail';
 import { getPost } from '@/lib/api';
+import { postMetadata } from '@/lib/seo';
 import 'katex/dist/katex.min.css';
 import '@/styles/prose.css';
 
@@ -12,10 +13,7 @@ interface Props {
 export async function generateMetadata({ params }: Props): Promise<Metadata> {
   const { slug } = await params;
   const post = await getPost(slug);
-  return {
-    title: post.seoTitle ?? post.title,
-    description: post.seoDescription ?? post.excerpt,
-  };
+  return postMetadata(post);
 }
 
 export default async function ProjectPage({ params }: Props) {

--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -1,0 +1,11 @@
+import type { MetadataRoute } from 'next';
+import { siteUrl } from '@/lib/seo';
+
+export default function robots(): MetadataRoute.Robots {
+  const base = siteUrl();
+  return {
+    rules: { userAgent: '*', allow: '/', disallow: '/search' },
+    sitemap: `${base}/sitemap.xml`,
+    host: base,
+  };
+}

--- a/src/app/rss.xml/route.ts
+++ b/src/app/rss.xml/route.ts
@@ -1,0 +1,62 @@
+import { getPosts } from '@/lib/api';
+import { siteUrl } from '@/lib/seo';
+
+const escapeXml = (value: string): string =>
+  value.replace(/[<>&'"]/g, (char) => {
+    switch (char) {
+      case '<':
+        return '&lt;';
+      case '>':
+        return '&gt;';
+      case '&':
+        return '&amp;';
+      case "'":
+        return '&apos;';
+      default:
+        return '&quot;';
+    }
+  });
+
+export async function GET() {
+  const base = siteUrl();
+  // The blog feed covers articles; projects are portfolio items, not feed posts.
+  const { items } = await getPosts('article', 1, 50);
+
+  const entries = items
+    .map((post) => {
+      const url = `${base}/blog/${post.slug}`;
+      const date = post.publishedAt ? new Date(post.publishedAt).toUTCString() : '';
+      return [
+        '    <item>',
+        `      <title>${escapeXml(post.title)}</title>`,
+        `      <link>${url}</link>`,
+        `      <guid isPermaLink="true">${url}</guid>`,
+        date ? `      <pubDate>${date}</pubDate>` : '',
+        `      <description>${escapeXml(post.excerpt)}</description>`,
+        ...post.tags.map((tag) => `      <category>${escapeXml(tag)}</category>`),
+        '    </item>',
+      ]
+        .filter(Boolean)
+        .join('\n');
+    })
+    .join('\n');
+
+  const xml = `<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
+  <channel>
+    <title>Mikhail Bahdashych — Blog</title>
+    <link>${base}</link>
+    <description>Security engineering notes: detection engineering, cloud security, write-ups.</description>
+    <language>en</language>
+    <atom:link href="${base}/rss.xml" rel="self" type="application/rss+xml" />
+${entries}
+  </channel>
+</rss>`;
+
+  return new Response(xml, {
+    headers: {
+      'Content-Type': 'application/rss+xml; charset=utf-8',
+      'Cache-Control': 'public, max-age=3600',
+    },
+  });
+}

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,0 +1,27 @@
+import type { MetadataRoute } from 'next';
+import { getSlugs } from '@/lib/api';
+import { siteUrl } from '@/lib/seo';
+
+// Depends on the API (post slugs); render on request, not at build time.
+export const dynamic = 'force-dynamic';
+
+export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
+  const base = siteUrl();
+  const slugs = await getSlugs();
+
+  const staticRoutes: MetadataRoute.Sitemap = [
+    { url: base, changeFrequency: 'weekly', priority: 1 },
+    { url: `${base}/blog`, changeFrequency: 'weekly', priority: 0.8 },
+    { url: `${base}/projects`, changeFrequency: 'weekly', priority: 0.8 },
+    { url: `${base}/about`, changeFrequency: 'monthly', priority: 0.6 },
+  ];
+
+  const postRoutes: MetadataRoute.Sitemap = slugs.map((entry) => ({
+    url: `${base}/${entry.type === 'article' ? 'blog' : 'projects'}/${entry.slug}`,
+    lastModified: entry.updatedAt,
+    changeFrequency: 'monthly',
+    priority: 0.7,
+  }));
+
+  return [...staticRoutes, ...postRoutes];
+}

--- a/src/lib/seo.ts
+++ b/src/lib/seo.ts
@@ -1,0 +1,79 @@
+import type { Metadata } from 'next';
+import { requireEnv } from './env';
+
+export function siteUrl(): string {
+  return requireEnv('NEXT_PUBLIC_SITE_URL');
+}
+
+/**
+ * Base metadata shared by every route: absolute-URL resolution, canonical,
+ * and the Open Graph + Twitter card defaults. Per-page metadata merges on top.
+ */
+export function baseMetadata(config: {
+  seoDefaultTitle: string;
+  seoDefaultDescription: string;
+}): Metadata {
+  const url = siteUrl();
+  return {
+    metadataBase: new URL(url),
+    title: {
+      default: config.seoDefaultTitle,
+      template: '%s · Mikhail Bahdashych',
+    },
+    description: config.seoDefaultDescription,
+    alternates: { canonical: '/' },
+    openGraph: {
+      type: 'website',
+      siteName: 'Mikhail Bahdashych',
+      url,
+      title: config.seoDefaultTitle,
+      description: config.seoDefaultDescription,
+    },
+    twitter: {
+      card: 'summary_large_image',
+      title: config.seoDefaultTitle,
+      description: config.seoDefaultDescription,
+    },
+    icons: { icon: '/favicon.svg' },
+  };
+}
+
+/** Per-post metadata: canonical path, article/website OG, optional hero image. */
+export function postMetadata(post: {
+  type: 'article' | 'project';
+  slug: string;
+  title: string;
+  seoTitle: string | null;
+  seoDescription: string | null;
+  excerpt: string;
+  heroUrl: string | null;
+  publishedAt: string | null;
+  updatedAt: string;
+}): Metadata {
+  const path = `/${post.type === 'article' ? 'blog' : 'projects'}/${post.slug}`;
+  const title = post.seoTitle ?? post.title;
+  const description = post.seoDescription ?? post.excerpt;
+  const images = post.heroUrl ? [{ url: post.heroUrl }] : undefined;
+
+  return {
+    title,
+    description,
+    alternates: { canonical: path },
+    openGraph: {
+      type: post.type === 'article' ? 'article' : 'website',
+      url: path,
+      title,
+      description,
+      images,
+      ...(post.type === 'article' && post.publishedAt
+        ? { publishedTime: post.publishedAt, modifiedTime: post.updatedAt }
+        : {}),
+    },
+    twitter: {
+      card: images ? 'summary_large_image' : 'summary',
+      title,
+      description,
+      images: post.heroUrl ? [post.heroUrl] : undefined,
+    },
+  };
+}


### PR DESCRIPTION
Final frontend milestone, stacked on #82. The frontend repo is now feature-complete.

## SEO
- `lib/seo.ts`: `metadataBase`, canonical URLs, Open Graph + Twitter cards; per-post metadata (article OG with published/modified time and hero image) wired into the root layout and both detail routes.
- JSON-LD (`BlogPosting`/`CreativeWork`) rendered server-side (from F2).
- `sitemap.xml` (dynamic, built from API slugs), `robots.txt` (disallows `/search`, points at the sitemap), `rss.xml` (articles feed, XML-escaped, atom self-link), `icon.svg` favicon.

## Revalidation
`POST /api/revalidate` — constant-time secret check, then `revalidateTag` for each tag. This closes the loop with the API: admin edits invalidate exactly the affected pages. Rejects a bad secret with 401.

## Ship
- Multi-stage **Dockerfile** (Next standalone output, `NEXT_PUBLIC_*` as build args, healthcheck, non-root).
- **CI**: typecheck + Vitest → buildx → GHCR → SSH deploy with the same hardening as the API (runner-IP-only SG rule, pinned host key, `if: always()` revoke).

## Verified
- `sitemap.xml` / `robots.txt` / `rss.xml` output checked; article `<head>` has canonical + OG (`article`) + Twitter + `BlogPosting` JSON-LD; `/api/revalidate` returns 401 on bad secret, 200 + `revalidateTag` on good.
- **Docker image built and booted** (standalone `server.js`) — home, article, and sitemap all 200 against the API.
- Typecheck + 10/10 Vitest + `next build` clean.

## Merge order
#79 → #80 → #81 → #82 → this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)