### PR TITLE
Security: block executable URLs in markdown, unmount the image optimizer

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -78,7 +78,10 @@ jobs:
           echo "${{ secrets.EC2_SSH_HOST_KEY }}" > ~/.ssh/known_hosts
           ssh -i ~/.ssh/deploy_key -o StrictHostKeyChecking=yes \
             "${{ secrets.EC2_SSH_USER }}@${{ secrets.EC2_HOST }}" \
-            'cd /opt/blog && docker compose pull front && docker compose up -d front && docker image prune -f'
+            'cd /opt/blog \
+             && docker compose -f docker-compose.prod.yml pull front \
+             && docker compose -f docker-compose.prod.yml up -d front \
+             && docker image prune -f'
       - name: Revoke SSH access
         if: always()
         run: |

--- a/next.config.ts
+++ b/next.config.ts
@@ -4,6 +4,12 @@ const nextConfig: NextConfig = {
   output: 'standalone',
   reactStrictMode: true,
   poweredByHeader: false,
+  // Nothing here uses next/image, but /_next/image is mounted regardless and
+  // feeds request-controlled input to sharp, which carries open libvips
+  // advisories (GHSA-f88m-g3jw-g9cj). This unmounts the route — it now 404s —
+  // so no request can reach sharp, instead of relying on remotePatterns being
+  // empty to reject remote sources.
+  images: { unoptimized: true },
 };
 
 export default nextConfig;

--- a/src/lib/markdown.test.ts
+++ b/src/lib/markdown.test.ts
@@ -84,4 +84,36 @@ describe('renderMarkdown', () => {
     expect(html).not.toContain('<img');
     expect(html).toContain('hello');
   });
+  it('strips executable URL schemes from links and images (XSS regression)', async () => {
+    // Raw HTML is dropped by remark-rehype, but markdown link syntax reaches the
+    // href untouched — rehypeSafeUrls is what stops `javascript:` there.
+    for (const md of [
+      '[c](javascript:alert(1))',
+      '[c](JaVaScRiPt:alert(1))',
+      '[c](  javascript:alert(1))',
+      '[c](vbscript:msgbox(1))',
+      '[c](data:text/html;base64,PHNjcmlwdD4=)',
+      '![i](javascript:alert(1))',
+    ]) {
+      const { html } = await renderMarkdown(md);
+      expect(html).not.toContain('javascript:');
+      expect(html).not.toContain('vbscript:');
+      expect(html).not.toContain('data:text/html');
+      expect(html).not.toMatch(/<(a|img)[^>]*\s(href|src)=/);
+    }
+  });
+
+  it('keeps the URLs a post legitimately needs', async () => {
+    const { html } = await renderMarkdown(
+      '[a](https://example.com) [b](/blog/post) [c](#anchor) [d](mailto:x@y.co)\n\n' +
+        '![e](https://bucket.s3.eu-central-1.amazonaws.com/uploads/2026/08/a-b_c.png)',
+    );
+    expect(html).toContain('href="https://example.com"');
+    expect(html).toContain('href="/blog/post"');
+    expect(html).toContain('href="#anchor"');
+    expect(html).toContain('href="mailto:x@y.co"');
+    expect(html).toContain(
+      'src="https://bucket.s3.eu-central-1.amazonaws.com/uploads/2026/08/a-b_c.png"',
+    );
+  });
 });

--- a/src/lib/markdown.ts
+++ b/src/lib/markdown.ts
@@ -25,6 +25,7 @@ import type { VFile } from 'vfile';
  *   horizontally scrollable container.
  * - H2 headings define the table of contents (slug ids from rehype-slug).
  * - Raw HTML is NOT rendered — it stays escaped text.
+ * - Link and image URLs are restricted to safe schemes (see rehypeSafeUrls).
  */
 
 export interface TocEntry {
@@ -42,6 +43,43 @@ const isElement = (node: ElementContent | RootContent | undefined, tag?: string)
 
 const isWhitespace = (node: ElementContent | RootContent | undefined): boolean =>
   !!node && node.type === 'text' && node.value.trim() === '';
+
+/**
+ * Strip link/image URLs that carry an executable scheme.
+ *
+ * remark-rehype does not filter URLs, so `[x](javascript:alert(1))` otherwise
+ * survives into the rendered href even though raw HTML is escaped. Anything
+ * without a scheme (relative paths, fragments, query-only) is left alone; a URL
+ * with a scheme has to be on the allowlist to be kept.
+ */
+const SAFE_URL_SCHEMES = new Set(['http:', 'https:', 'mailto:', 'tel:']);
+const URL_ATTRIBUTES: Record<string, string> = { a: 'href', img: 'src', image: 'href' };
+
+function isSafeUrl(value: string): boolean {
+  // Browsers drop whitespace and control characters while parsing a URL, so
+  // `java\tscript:alert(1)` still executes. Drop everything up to and including
+  // U+0020 before reading the scheme; over-stripping only ever fails closed.
+  const bare = Array.from(value)
+    .filter((char) => char.codePointAt(0)! > 0x20)
+    .join('');
+  const scheme = /^([a-z][a-z0-9+.-]*):/i.exec(bare);
+  return scheme === null || SAFE_URL_SCHEMES.has(scheme[1].toLowerCase() + ':');
+}
+
+function rehypeSafeUrls() {
+  return (tree: Root) => {
+    visit(tree, 'element', (node: Element) => {
+      const attribute = URL_ATTRIBUTES[node.tagName];
+      if (!attribute) {
+        return;
+      }
+      const value = node.properties[attribute];
+      if (typeof value === 'string' && !isSafeUrl(value)) {
+        delete node.properties[attribute];
+      }
+    });
+  };
+}
 
 /** `![alt](url "Caption")` alone in a paragraph -> <figure><img/><figcaption/></figure> */
 function rehypeFigures() {
@@ -162,6 +200,7 @@ const processor = unified()
   .use(rehypeTableCaptions)
   .use(rehypeTableWrap)
   .use(rehypeFigures)
+  .use(rehypeSafeUrls)
   .use(collectToc)
   .use(rehypeStringify);
 


### PR DESCRIPTION
Part of the pre-deployment security review. Companion to `personal-blog-api#49`.

## `javascript:` URLs survived into rendered links

remark-rehype drops raw HTML, but leaves link and image URLs untouched — so `[click](javascript:alert(1))` rendered a live `href`, and `![x](javascript:…)` a live `src`. Confirmed executing in a real browser against a published post.

`rehypeSafeUrls` restricts `href`/`src` to `http`, `https`, `mailto`, `tel` and drops the attribute otherwise. Schemes are read the way a browser reads them (control characters and spaces stripped first), so `JaVaScRiPt:`, `  javascript:` and `data:text/html` are all caught. Relative paths, anchors and mailto links are unaffected.

Verified in-browser after the fix: `window.__pwned` never set, no `<script>` in the rendered prose, no inline handlers, hostile `href`/`src` attributes absent entirely, legitimate `https:`/relative/anchor/mailto URLs intact.

Regression tests added for both the blocked and the allowed cases.

## `/_next/image` unmounted

Nothing here uses `next/image`, but the optimizer route is mounted regardless and passes request-controlled input to `sharp`, which carries open libvips advisories (GHSA-f88m-g3jw-g9cj — the high-severity `npm audit` finding). `images: { unoptimized: true }` unmounts the route: it now returns **404**, confirmed against the built standalone server. That closes the path without the `next@16` major bump.

`postcss`, the other advisory in that audit chain, runs at build time only and never sees untrusted CSS.

## On `REVALIDATE_SECRET` — not exposed

It is read only inside the `/api/revalidate` route handler (`runtime = 'nodejs'`) and carries no `NEXT_PUBLIC_` prefix, so Next never inlines it into the client bundle. Verified two ways: it appears in `.next/server/` but not `.next/static/`, and scanning the **476KB of JS a page actually loads in the browser** found no secret of any kind — only `NEXT_PUBLIC_API_URL`, which is meant to be public. The webhook itself is guarded by a constant-time comparison.

## Also

The deploy step now names `docker-compose.prod.yml`, matching the API's workflow — plain `docker compose` finds no compose file on the host, so the current step would fail at cutover.

🤖 Generated with [Claude Code](https://claude.com/claude-code)