### PR TITLE
Favicon 404, numbered contents, page-size control, block reveal

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,4 +1,5 @@
 import Link from 'next/link';
+import type { CSSProperties } from 'react';
 import { PostRow } from '@/components/post-row';
 import { getFeatured, getSiteConfig } from '@/lib/api';
 
@@ -11,10 +12,12 @@ export default async function HomePage() {
 
   return (
     <>
-      <h1 className="hero-title">{config.heroTitle}</h1>
-      <p className="hero-intro">{config.heroIntroMd}</p>
+      <h1 className="hero-title reveal">{config.heroTitle}</h1>
+      <p className="hero-intro reveal" style={{ '--i': 1 } as CSSProperties}>
+        {config.heroIntroMd}
+      </p>
 
-      <section className="home-section">
+      <section className="home-section reveal" style={{ '--i': 2 } as CSSProperties}>
         <div className="section-row">
           <h2 className="micro-label">Featured articles</h2>
           <Link href="/blog" className="all-link">
@@ -22,8 +25,8 @@ export default async function HomePage() {
           </Link>
         </div>
         <div className="post-list">
-          {articles.items.map((post) => (
-            <PostRow key={post.slug} post={post} />
+          {articles.items.map((post, index) => (
+            <PostRow key={post.slug} post={post} index={index} />
           ))}
         </div>
       </section>
@@ -36,8 +39,8 @@ export default async function HomePage() {
           </Link>
         </div>
         <div className="post-list">
-          {projects.items.map((post) => (
-            <PostRow key={post.slug} post={post} />
+          {projects.items.map((post, index) => (
+            <PostRow key={post.slug} post={post} index={index} />
           ))}
         </div>
       </section>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -25,8 +25,8 @@ export default async function HomePage() {
           </Link>
         </div>
         <div className="post-list">
-          {articles.items.map((post, index) => (
-            <PostRow key={post.slug} post={post} index={index} />
+          {articles.items.map((post) => (
+            <PostRow key={post.slug} post={post} />
           ))}
         </div>
       </section>
@@ -39,8 +39,8 @@ export default async function HomePage() {
           </Link>
         </div>
         <div className="post-list">
-          {projects.items.map((post, index) => (
-            <PostRow key={post.slug} post={post} index={index} />
+          {projects.items.map((post) => (
+            <PostRow key={post.slug} post={post} />
           ))}
         </div>
       </section>

--- a/src/components/listing.tsx
+++ b/src/components/listing.tsx
@@ -39,9 +39,9 @@ export async function Listing({ type, title, basePath, page, per }: Props) {
         <EmptyState>Nothing here yet.</EmptyState>
       ) : (
         <>
-          <div className="post-list listing">
-            {list.items.map((post, index) => (
-              <PostRow key={post.slug} post={post} index={index} />
+          <div className="post-list listing reveal">
+            {list.items.map((post) => (
+              <PostRow key={post.slug} post={post} />
             ))}
           </div>
           <Pagination basePath={basePath} total={list.total} page={page} per={per} />

--- a/src/components/listing.tsx
+++ b/src/components/listing.tsx
@@ -40,8 +40,8 @@ export async function Listing({ type, title, basePath, page, per }: Props) {
       ) : (
         <>
           <div className="post-list listing">
-            {list.items.map((post) => (
-              <PostRow key={post.slug} post={post} />
+            {list.items.map((post, index) => (
+              <PostRow key={post.slug} post={post} index={index} />
             ))}
           </div>
           <Pagination basePath={basePath} total={list.total} page={page} per={per} />

--- a/src/components/pagination.tsx
+++ b/src/components/pagination.tsx
@@ -2,6 +2,7 @@
 
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
+import { useTransition } from 'react';
 import { PER_PAGE_OPTIONS } from '@/lib/format';
 
 /** 1 … around-current … last, per the mockup's pagination bar. */
@@ -34,18 +35,25 @@ interface Props {
 
 export function Pagination({ basePath, total, page, per }: Props) {
   const router = useRouter();
+  // Changing the page size is a server round trip. Without a pending state the
+  // bar looks inert — and on a short list, where the row count does not visibly
+  // change, it looks like the control did nothing at all.
+  const [pending, startTransition] = useTransition();
   const totalPages = Math.max(1, Math.ceil(total / per));
   const href = (p: number, perValue = per) => `${basePath}?page=${p}&per=${perValue}`;
 
   return (
-    <div className="pagination">
+    <div className={pending ? 'pagination is-pending' : 'pagination'} aria-busy={pending}>
       <label className="per-select">
         <span>per page</span>
         <span className="per-chip">
           <select
             value={per}
             aria-label="Results per page"
-            onChange={(event) => router.push(href(1, Number(event.target.value)))}
+            onChange={(event) => {
+              const next = Number(event.target.value);
+              startTransition(() => router.push(href(1, next)));
+            }}
           >
             {PER_PAGE_OPTIONS.map((option) => (
               <option key={option} value={option}>

--- a/src/components/pagination.tsx
+++ b/src/components/pagination.tsx
@@ -38,9 +38,26 @@ export function Pagination({ basePath, total, page, per }: Props) {
   // Changing the page size is a server round trip. Without a pending state the
   // bar looks inert — and on a short list, where the row count does not visibly
   // change, it looks like the control did nothing at all.
+  //
+  // The control is also locked while that request is in flight. Starting a
+  // second navigation before the first lands leaves two of them racing to
+  // commit, and the loser can be the one that matches the address bar.
   const [pending, startTransition] = useTransition();
   const totalPages = Math.max(1, Math.ceil(total / per));
   const href = (p: number, perValue = per) => `${basePath}?page=${p}&per=${perValue}`;
+
+  // While a navigation is in flight, page links become inert spans so a second
+  // one cannot be started on top of it.
+  const navLink = (p: number, label: string, extra = '') =>
+    pending ? (
+      <span key={label + p} className={`page-btn disabled ${extra}`.trim()}>
+        {label}
+      </span>
+    ) : (
+      <Link key={label + p} className={`page-btn ${extra}`.trim()} href={href(p)}>
+        {label}
+      </Link>
+    );
 
   return (
     <div className={pending ? 'pagination is-pending' : 'pagination'} aria-busy={pending}>
@@ -50,6 +67,7 @@ export function Pagination({ basePath, total, page, per }: Props) {
           <select
             value={per}
             aria-label="Results per page"
+            disabled={pending}
             onChange={(event) => {
               const next = Number(event.target.value);
               startTransition(() => router.push(href(1, next)));
@@ -79,12 +97,10 @@ export function Pagination({ basePath, total, page, per }: Props) {
 
       <nav className="page-nav" aria-label="Pagination">
         {page > 1 ? (
-          <Link className="page-btn" href={href(page - 1)} aria-label="Previous page">
-            ‹
-          </Link>
+          navLink(page - 1, '\u2039')
         ) : (
           <span className="page-btn disabled" aria-hidden="true">
-            ‹
+            &lsaquo;
           </span>
         )}
         {pageNumbers(totalPages, page).map((n, i) =>
@@ -92,24 +108,19 @@ export function Pagination({ basePath, total, page, per }: Props) {
             <span key={`gap-${i}`} className="page-ellipsis">
               …
             </span>
-          ) : (
-            <Link
-              key={n}
-              className={n === page ? 'page-btn active' : 'page-btn'}
-              href={href(n)}
-              aria-current={n === page ? 'page' : undefined}
-            >
+          ) : n === page ? (
+            <span key={n} className="page-btn active" aria-current="page">
               {n}
-            </Link>
+            </span>
+          ) : (
+            navLink(n, String(n))
           ),
         )}
         {page < totalPages ? (
-          <Link className="page-btn" href={href(page + 1)} aria-label="Next page">
-            ›
-          </Link>
+          navLink(page + 1, '\u203a')
         ) : (
           <span className="page-btn disabled" aria-hidden="true">
-            ›
+            &rsaquo;
           </span>
         )}
       </nav>

--- a/src/components/post-row.tsx
+++ b/src/components/post-row.tsx
@@ -1,14 +1,12 @@
 import Link from 'next/link';
-import type { CSSProperties } from 'react';
 import { fmtDate, fmtYear } from '@/lib/format';
 import type { PostListItem } from '@/lib/types';
 
-export function PostRow({ post, index = 0 }: { post: PostListItem; index?: number }) {
+export function PostRow({ post }: { post: PostListItem }) {
   const href = post.type === 'article' ? `/blog/${post.slug}` : `/projects/${post.slug}`;
 
   return (
-    // --i drives the stagger in the reveal animation (see globals.css).
-    <article className="post-row reveal" style={{ '--i': index } as CSSProperties}>
+    <article className="post-row">
       <div>
         <Link href={href} className="post-title">
           {post.title}

--- a/src/components/post-row.tsx
+++ b/src/components/post-row.tsx
@@ -1,12 +1,14 @@
 import Link from 'next/link';
+import type { CSSProperties } from 'react';
 import { fmtDate, fmtYear } from '@/lib/format';
 import type { PostListItem } from '@/lib/types';
 
-export function PostRow({ post }: { post: PostListItem }) {
+export function PostRow({ post, index = 0 }: { post: PostListItem; index?: number }) {
   const href = post.type === 'article' ? `/blog/${post.slug}` : `/projects/${post.slug}`;
 
   return (
-    <article className="post-row">
+    // --i drives the stagger in the reveal animation (see globals.css).
+    <article className="post-row reveal" style={{ '--i': index } as CSSProperties}>
       <div>
         <Link href={href} className="post-title">
           {post.title}

--- a/src/components/toc-card.tsx
+++ b/src/components/toc-card.tsx
@@ -9,8 +9,11 @@ export function TocCard({ toc }: { toc: TocEntry[] }) {
     <nav className="toc-card" aria-label="Contents">
       <span className="micro-label">Contents</span>
       <div className="toc-list">
-        {toc.map((entry) => (
+        {toc.map((entry, index) => (
           <a key={entry.id} href={`#${entry.id}`}>
+            {/* Numbering mirrors the counter on .prose h2 — both walk the H2s
+                in document order, so they stay in step. */}
+            <span className="toc-num">{index + 1}.</span>
             {entry.text}
           </a>
         ))}

--- a/src/lib/seo.ts
+++ b/src/lib/seo.ts
@@ -34,7 +34,9 @@ export function baseMetadata(config: {
       title: config.seoDefaultTitle,
       description: config.seoDefaultDescription,
     },
-    icons: { icon: '/favicon.svg' },
+    // No `icons` override: src/app/icon.svg is picked up by Next's file
+    // convention and linked with a content hash. Naming a path here pointed at
+    // /favicon.svg, which does not exist — every page 404'd and shipped no icon.
   };
 }
 

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -14,12 +14,17 @@ html {
 
 /* --- Content reveal ----------------------------------------------------------
  * Pages are server-rendered, so there is nothing to wait for — the point is to
- * let blocks settle in rather than snap. Purely CSS: no JS, no layout shift
- * (only opacity and transform animate), and `both` holds the start frame so
- * nothing flashes before its delay elapses.
+ * let blocks settle in rather than snap. Purely CSS: no JS, no layout shift,
+ * only opacity and transform.
  *
- * Elements set --i to stagger themselves; the cap keeps a long list from
- * leaving the last rows invisible for a noticeable beat.
+ * This is applied to whole blocks (a listing, a section), never to individual
+ * rows. Staggering each row meant every row spent its delay at opacity 0, so a
+ * post could sit invisible while the ones around it had already arrived —
+ * indistinguishable from a post that failed to load.
+ *
+ * `backwards` holds the opening frame during the delay but hands the element
+ * back to its natural, visible state afterwards, so nothing can be left
+ * stranded by an interrupted animation.
  */
 @keyframes reveal-rise {
   from {
@@ -33,8 +38,8 @@ html {
 }
 
 .reveal {
-  animation: reveal-rise 460ms cubic-bezier(0.22, 0.61, 0.36, 1) both;
-  animation-delay: calc(min(var(--i, 0), 8) * 45ms);
+  animation: reveal-rise 420ms cubic-bezier(0.22, 0.61, 0.36, 1) backwards;
+  animation-delay: calc(min(var(--i, 0), 3) * 60ms);
 }
 
 @media (prefers-reduced-motion: reduce) {

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -12,6 +12,37 @@ html {
   -webkit-text-size-adjust: 100%;
 }
 
+/* --- Content reveal ----------------------------------------------------------
+ * Pages are server-rendered, so there is nothing to wait for — the point is to
+ * let blocks settle in rather than snap. Purely CSS: no JS, no layout shift
+ * (only opacity and transform animate), and `both` holds the start frame so
+ * nothing flashes before its delay elapses.
+ *
+ * Elements set --i to stagger themselves; the cap keeps a long list from
+ * leaving the last rows invisible for a noticeable beat.
+ */
+@keyframes reveal-rise {
+  from {
+    opacity: 0;
+    transform: translateY(8px);
+  }
+  to {
+    opacity: 1;
+    transform: none;
+  }
+}
+
+.reveal {
+  animation: reveal-rise 460ms cubic-bezier(0.22, 0.61, 0.36, 1) both;
+  animation-delay: calc(min(var(--i, 0), 8) * 45ms);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .reveal {
+    animation: none;
+  }
+}
+
 body {
   background: var(--bg);
   color: var(--text);
@@ -367,15 +398,18 @@ h3 {
   gap: 10px;
 }
 
+/*
+ * The chip is only a frame: the select fills it edge to edge and carries the
+ * padding, so clicking anywhere in the box — including the chevron — opens the
+ * menu. Previously only the digits themselves were a hit target.
+ */
 .per-chip {
   position: relative;
   display: inline-flex;
   align-items: center;
-  gap: 6px;
   border: 1px solid var(--border);
   border-radius: 6px;
   background: var(--surface);
-  padding: 5px 10px;
   color: var(--text);
 }
 
@@ -390,11 +424,43 @@ h3 {
   color: inherit;
   font: inherit;
   cursor: pointer;
-  padding-right: 2px;
+  padding: 5px 26px 5px 10px;
+  width: 100%;
 }
 
-.per-chip select:focus {
-  outline: none;
+.per-chip select:focus-visible {
+  outline: 2px solid var(--link-tint);
+  outline-offset: 1px;
+  border-radius: 5px;
+}
+
+/* Decorative only — never swallow a click meant for the select beneath it. */
+.per-chip svg {
+  position: absolute;
+  right: 9px;
+  pointer-events: none;
+}
+
+/* Feedback while the new page is being fetched. */
+.pagination.is-pending {
+  opacity: 0.55;
+  transition: opacity 120ms ease-out;
+}
+
+.pagination.is-pending .per-chip svg {
+  animation: per-chip-spin 700ms linear infinite;
+}
+
+@keyframes per-chip-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .pagination.is-pending .per-chip svg {
+    animation: none;
+  }
 }
 
 .page-nav {

--- a/src/styles/prose.css
+++ b/src/styles/prose.css
@@ -12,12 +12,26 @@
   margin-top: 24px;
 }
 
+/*
+ * H2s are numbered to match the table of contents. The number is generated
+ * rather than authored so the two can never drift, and so heading ids stay
+ * clean (#the-audience-claim-problem, not #1-the-audience-claim-problem).
+ */
+.prose {
+  counter-reset: prose-section;
+}
+
 .prose h2 {
   margin-top: 40px;
   font-family: var(--font-sans);
   font-size: 19px;
   font-weight: 600;
   color: var(--text);
+  counter-increment: prose-section;
+}
+
+.prose h2::before {
+  content: counter(prose-section) '. ';
 }
 
 .prose h2 + * {
@@ -222,6 +236,12 @@
   font-size: 13px;
   color: var(--body);
   text-decoration: none;
+}
+
+.toc-num {
+  margin-right: 6px;
+  color: var(--muted);
+  font-variant-numeric: tabular-nums;
 }
 
 .toc-list a:hover {


### PR DESCRIPTION
Findings from driving the running site in a browser, across three rounds.

## The page-size control

Two separate problems, both real.

**Only the digits were clickable.** The `<select>` was sized to its own text inside a padded chip, with the chevron layered on top. It now fills the chip and the chevron is click-through — verified by hit-testing five points across the box, every one now resolves to the `<select>`.

**Overlapping navigations could commit the wrong result.** Changing the page size is a server round trip; starting a second one before the first lands leaves two racing, and the loser can be the one that matches the address bar. I reproduced this once — `?per=50` rendering 3 rows — and it matches the report of "50 shows only 3". The control and the page links now lock while a request is in flight, so a second navigation cannot start on top of the first. Eight rounds of deliberate rapid switching afterwards: zero anomalies.

Server-side rendering was never wrong — `/blog?per=N` returns the right count for every N — which is why this only ever showed up as a client-side glitch.

## The reveal was hiding rows

Staggering per row meant every row spent its delay at `opacity: 0` — measured at over a second after a page-size change. A post sitting invisible while its neighbours had arrived is indistinguishable from one that failed to load, which is very likely the "one post remains invisible" half of the report.

It now animates whole blocks, never individual rows, and uses `backwards` fill so an interrupted animation hands the element back visible instead of stranding it.

## Numbered table of contents

The mockup numbers the contents list *and* the H2s in the body; neither was numbered. The body numbers come from a CSS counter rather than being authored, so the two cannot drift and heading ids stay clean (`#detection-and-hardening`, not `#3-detection-and-hardening`).

## Favicon 404

`baseMetadata` declared `icons: { icon: '/favicon.svg' }`, but the icon is `src/app/icon.svg`, served from `/icon.svg`. **Every page load requested a missing file** and the site shipped no icon. Removing the override lets Next's file convention emit `/icon.svg?<hash>` — verified 200.

🤖 Generated with [Claude Code](https://claude.com/claude-code)