### PR TITLE
Add an interactive terminal to the home page

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,49 +1,79 @@
 import Link from 'next/link';
 import type { CSSProperties } from 'react';
 import { PostRow } from '@/components/post-row';
-import { getFeatured, getSiteConfig } from '@/lib/api';
+import { Terminal } from '@/components/terminal/terminal';
+import { buildTerminalData } from '@/components/terminal/vfs';
+import { getAbout, getFeatured, getSiteConfig, getSlugs } from '@/lib/api';
+import { siteUrl } from '@/lib/seo';
+import '@/styles/terminal.css';
+
+/** The resident. Decoration only, hence aria-hidden where it is rendered. */
+const PET = ' /\\_/\\\n( o.o )\n > ^ <';
 
 export default async function HomePage() {
-  const [config, articles, projects] = await Promise.all([
+  const [config, about, articles, projects, slugs] = await Promise.all([
     getSiteConfig(),
+    getAbout(),
     getFeatured('article'),
     getFeatured('project'),
+    getSlugs(),
   ]);
 
+  // The little shell beside the hero. It shares this page's data — nothing in
+  // it is fetched separately or hardcoded beyond the jokes.
+  const terminalData = buildTerminalData({
+    host: new URL(siteUrl()).hostname,
+    config,
+    about,
+    articles,
+    projects,
+    slugs,
+    now: Date.now(),
+  });
+
   return (
-    <>
-      <h1 className="hero-title reveal">{config.heroTitle}</h1>
-      <p className="hero-intro reveal" style={{ '--i': 1 } as CSSProperties}>
-        {config.heroIntroMd}
-      </p>
+    <div className="home-grid">
+      <div className="home-main">
+        <h1 className="hero-title reveal">{config.heroTitle}</h1>
+        <div className="hero-lede reveal" style={{ '--i': 1 } as CSSProperties}>
+          <pre className="hero-pet" aria-hidden="true">
+            {PET}
+          </pre>
+          <p className="hero-intro">{config.heroIntroMd}</p>
+        </div>
 
-      <section className="home-section reveal" style={{ '--i': 2 } as CSSProperties}>
-        <div className="section-row">
-          <h2 className="micro-label">Featured articles</h2>
-          <Link href="/blog" className="all-link">
-            All articles →
-          </Link>
-        </div>
-        <div className="post-list">
-          {articles.items.map((post) => (
-            <PostRow key={post.slug} post={post} />
-          ))}
-        </div>
-      </section>
+        <Terminal data={terminalData} />
+      </div>
 
-      <section className="home-section">
-        <div className="section-row">
-          <h2 className="micro-label">Featured projects</h2>
-          <Link href="/projects" className="all-link">
-            All projects →
-          </Link>
-        </div>
-        <div className="post-list">
-          {projects.items.map((post) => (
-            <PostRow key={post.slug} post={post} />
-          ))}
-        </div>
-      </section>
-    </>
+      <aside className="home-side">
+        <section className="home-section reveal" style={{ '--i': 3 } as CSSProperties}>
+          <div className="section-row">
+            <h2 className="micro-label">Featured articles</h2>
+            <Link href="/blog" className="all-link">
+              All articles →
+            </Link>
+          </div>
+          <div className="post-list">
+            {articles.items.map((post) => (
+              <PostRow key={post.slug} post={post} />
+            ))}
+          </div>
+        </section>
+
+        <section className="home-section">
+          <div className="section-row">
+            <h2 className="micro-label">Featured projects</h2>
+            <Link href="/projects" className="all-link">
+              All projects →
+            </Link>
+          </div>
+          <div className="post-list">
+            {projects.items.map((post) => (
+              <PostRow key={post.slug} post={post} />
+            ))}
+          </div>
+        </section>
+      </aside>
+    </div>
   );
 }

--- a/src/components/terminal/commands.ts
+++ b/src/components/terminal/commands.ts
@@ -1,0 +1,421 @@
+import {
+  FileContent,
+  TerminalData,
+  VfsDir,
+  VfsFile,
+  VfsNode,
+  formatCwd,
+  getNode,
+  resolvePath,
+  visibleChildren,
+} from './vfs';
+
+/**
+ * The command layer: pure functions from (context, input line) to output
+ * blocks plus optional side effects. Nothing here touches the DOM — the
+ * Terminal component applies effects and a renderer turns blocks into JSX,
+ * which is what keeps this whole layer unit-testable.
+ */
+
+export type Tone = 'default' | 'dim' | 'error' | 'ok';
+
+export interface TextLine {
+  text: string;
+  tone?: Tone;
+}
+
+export interface LsEntry {
+  name: string;
+  kind: 'dir' | 'file';
+  href: string | null;
+  title: string | null;
+  meta: string | null;
+}
+
+export type Block =
+  | { kind: 'lines'; lines: TextLine[] }
+  | { kind: 'ls'; entries: LsEntry[]; footer: { text: string; href: string } | null }
+  | { kind: 'file'; file: FileContent }
+  | { kind: 'neofetch'; art: string[]; rows: [string, string][] }
+  | { kind: 'help'; rows: [string, string][]; footer: string }
+  | { kind: 'completions'; items: string[] };
+
+export type Effect =
+  | { kind: 'navigate'; href: string }
+  | { kind: 'clear' }
+  | { kind: 'theme'; mode: 'dark' | 'light' }
+  | { kind: 'exit' };
+
+export interface RunResult {
+  blocks: Block[];
+  cwd?: string[];
+  effect?: Effect;
+}
+
+export interface Context {
+  data: TerminalData;
+  root: VfsDir;
+  cwd: string[];
+  theme: 'dark' | 'light';
+  history: string[];
+}
+
+/** One line per visible command in `help`, in this order. */
+const HELP_ROWS: [string, string][] = [
+  ['ls [-a] [dir]', 'list what lives here'],
+  ['cd <dir>', 'move around'],
+  ['cat <file>', 'read a file'],
+  ['open <path>', 'open it for real, on the site'],
+  ['pwd', 'where am I?'],
+  ['neofetch', 'about this machine (me)'],
+  ['theme [dark|light]', 'flip the lights'],
+  ['clear', 'wipe the screen'],
+  ['help', 'this list'],
+];
+
+const HELP_FOOTER = 'tab completes · ↑↓ history · ctrl+c cancels · ctrl+l clears';
+
+/** Commands offered by tab completion — eggs stay discoverable, not advertised. */
+export const COMPLETABLE_COMMANDS = [
+  'cat',
+  'cd',
+  'clear',
+  'echo',
+  'exit',
+  'help',
+  'history',
+  'ls',
+  'neofetch',
+  'open',
+  'pwd',
+  'theme',
+  'whoami',
+];
+
+function lines(...items: (string | TextLine)[]): Block {
+  return {
+    kind: 'lines',
+    lines: items.map((item) => (typeof item === 'string' ? { text: item } : item)),
+  };
+}
+
+function error(text: string): Block {
+  return { kind: 'lines', lines: [{ text, tone: 'error' }] };
+}
+
+function lsEntry(node: VfsNode): LsEntry {
+  if (node.kind === 'dir') {
+    return {
+      name: `${node.name}/`,
+      kind: 'dir',
+      href: node.href,
+      title: null,
+      meta: `${node.children.filter((c) => c.hidden !== true).length} items`,
+    };
+  }
+  const { content } = node;
+  return {
+    name: node.name,
+    kind: 'file',
+    href: node.href,
+    title: content.kind === 'post' ? content.post.title : null,
+    meta: content.kind === 'post' ? content.post.date : null,
+  };
+}
+
+export function listDir(dir: VfsDir, showHidden: boolean): Block {
+  const entries = visibleChildren(dir, showHidden).map(lsEntry);
+  const footer =
+    dir.extraTotal > 0 && dir.href !== null
+      ? { text: `+ ${dir.extraTotal} more in the archive`, href: dir.href }
+      : null;
+  return { kind: 'ls', entries, footer };
+}
+
+function ls(ctx: Context, args: string[]): RunResult {
+  let showHidden = false;
+  const paths: string[] = [];
+  for (const arg of args) {
+    if (arg.startsWith('-')) {
+      for (const flag of arg.slice(1)) {
+        if (flag === 'a') {
+          showHidden = true;
+        } else if (flag !== 'l') {
+          return { blocks: [error(`ls: invalid option -- '${flag}'`)] };
+        }
+      }
+    } else {
+      paths.push(arg);
+    }
+  }
+  if (paths.length > 1) {
+    return { blocks: [error('ls: one directory at a time, please')] };
+  }
+
+  const target = paths[0] ?? '.';
+  const node = getNode(ctx.root, resolvePath(ctx.cwd, target));
+  if (!node) {
+    return { blocks: [error(`ls: cannot access '${target}': No such file or directory`)] };
+  }
+  if (node.kind === 'file') {
+    return { blocks: [{ kind: 'ls', entries: [lsEntry(node)], footer: null }] };
+  }
+  return { blocks: [listDir(node, showHidden)] };
+}
+
+function cd(ctx: Context, args: string[]): RunResult {
+  const target = args[0] ?? '~';
+  const path = resolvePath(ctx.cwd, target);
+  const node = getNode(ctx.root, path);
+  if (!node) {
+    return { blocks: [error(`cd: no such file or directory: ${target}`)] };
+  }
+  if (node.kind !== 'dir') {
+    return { blocks: [error(`cd: not a directory: ${target}`)] };
+  }
+  return { blocks: [], cwd: path };
+}
+
+function cat(ctx: Context, args: string[]): RunResult {
+  const target = args[0];
+  if (!target) {
+    return {
+      blocks: [error('cat: missing operand'), lines({ text: 'usage: cat <file>', tone: 'dim' })],
+    };
+  }
+  const node = getNode(ctx.root, resolvePath(ctx.cwd, target));
+  if (!node) {
+    return { blocks: [error(`cat: ${target}: No such file or directory`)] };
+  }
+  if (node.kind === 'dir') {
+    return { blocks: [error(`cat: ${target}: Is a directory`)] };
+  }
+  return { blocks: [{ kind: 'file', file: node.content }] };
+}
+
+function open(ctx: Context, args: string[]): RunResult {
+  const target = args[0];
+  if (!target) {
+    return {
+      blocks: [error('open: missing operand'), lines({ text: 'usage: open <path>', tone: 'dim' })],
+    };
+  }
+  const node = getNode(ctx.root, resolvePath(ctx.cwd, target));
+  if (!node) {
+    return { blocks: [error(`open: ${target}: No such file or directory`)] };
+  }
+  if (node.href === null) {
+    return {
+      blocks: [
+        error(`open: ${target}: nothing to open`),
+        lines({ text: 'try cat instead — it all lives right here', tone: 'dim' }),
+      ],
+    };
+  }
+  return {
+    blocks: [lines({ text: `opening ${node.href} …`, tone: 'dim' })],
+    effect: { kind: 'navigate', href: node.href },
+  };
+}
+
+function theme(ctx: Context, args: string[]): RunResult {
+  const arg = args[0];
+  if (arg !== undefined && arg !== 'dark' && arg !== 'light') {
+    return { blocks: [error(`theme: expected 'dark' or 'light', got '${arg}'`)] };
+  }
+  const mode = arg ?? (ctx.theme === 'dark' ? 'light' : 'dark');
+  return {
+    blocks: [lines({ text: `theme → ${mode}`, tone: 'ok' })],
+    effect: { kind: 'theme', mode },
+  };
+}
+
+const NEOFETCH_ART = [
+  '███╗   ███╗██████╗ ',
+  '████╗ ████║██╔══██╗',
+  '██╔████╔██║██████╔╝',
+  '██║╚██╔╝██║██╔══██╗',
+  '██║ ╚═╝ ██║██████╔╝',
+  '╚═╝     ╚═╝╚═════╝ ',
+];
+
+/**
+ * Pure function of the data, shared by the boot transcript and the typed
+ * command — the pre-run card and a later `neofetch` must print the same thing.
+ */
+export function neofetchBlock(data: TerminalData): Block {
+  const rows: [string, string][] = [['user', `guest@${data.host}`]];
+  if (data.role !== null) {
+    rows.push(['role', data.role]);
+  }
+  rows.push(['based', data.location]);
+  if (data.uptime !== null) {
+    rows.push(['uptime', data.uptime]);
+  }
+  if (data.topSkills.length > 0) {
+    rows.push(['stack', data.topSkills.join(' · ')]);
+  }
+  rows.push(['posts', `${data.articleTotal} articles · ${data.projectTotal} projects`]);
+  rows.push(['shell', 'zsh (emulated, obviously)']);
+  return { kind: 'neofetch', art: NEOFETCH_ART, rows };
+}
+
+function history(ctx: Context): RunResult {
+  if (ctx.history.length === 0) {
+    return { blocks: [lines({ text: 'history: nothing yet', tone: 'dim' })] };
+  }
+  return {
+    blocks: [
+      {
+        kind: 'lines',
+        lines: ctx.history.map((entry, i) => ({
+          text: `${String(i + 1).padStart(4)}  ${entry}`,
+        })),
+      },
+    ],
+  };
+}
+
+const READ_ONLY_COMMANDS = ['rm', 'mv', 'cp', 'touch', 'mkdir', 'chmod', 'chown'];
+const EDITOR_COMMANDS = ['vim', 'vi', 'nvim', 'nano', 'emacs'];
+
+export function run(ctx: Context, rawInput: string): RunResult {
+  const input = rawInput.trim();
+  if (input === '') {
+    return { blocks: [] };
+  }
+  const [command = '', ...args] = input.split(/\s+/);
+
+  switch (command) {
+    case 'help':
+      return { blocks: [{ kind: 'help', rows: HELP_ROWS, footer: HELP_FOOTER }] };
+    case 'ls':
+      return ls(ctx, args);
+    case 'cd':
+      return cd(ctx, args);
+    case 'pwd':
+      return { blocks: [lines(`/home/guest${ctx.cwd.map((s) => `/${s}`).join('')}`)] };
+    case 'cat':
+      return cat(ctx, args);
+    case 'open':
+      return open(ctx, args);
+    case 'clear':
+      return { blocks: [], effect: { kind: 'clear' } };
+    case 'echo':
+      return { blocks: [lines(input.slice(5))] };
+    case 'whoami':
+      return { blocks: [lines('guest', { text: '(make yourself at home)', tone: 'dim' })] };
+    case 'history':
+      return history(ctx);
+    case 'theme':
+      return theme(ctx, args);
+    case 'neofetch':
+    case 'fastfetch':
+    case 'fetch':
+      return { blocks: [neofetchBlock(ctx.data)] };
+    case 'sudo':
+      return {
+        blocks: [error('guest is not in the sudoers file. This incident will be reported.')],
+      };
+    case 'exit':
+    case 'logout':
+      return {
+        blocks: [
+          lines('logout', {
+            text: `Connection to ${ctx.data.host} closed. (the header up top still works)`,
+            tone: 'dim',
+          }),
+        ],
+        effect: { kind: 'exit' },
+      };
+    default:
+      if (READ_ONLY_COMMANDS.includes(command)) {
+        return { blocks: [error(`${command}: read-only file system (the blog stays)`)] };
+      }
+      if (EDITOR_COMMANDS.includes(command)) {
+        return {
+          blocks: [
+            lines(
+              { text: `${command}: no editors on this box`, tone: 'error' },
+              { text: 'the writing happens in a cozy admin panel far away', tone: 'dim' },
+            ),
+          ],
+        };
+      }
+      return {
+        blocks: [
+          error(`zsh: command not found: ${command}`),
+          lines({ text: "type 'help' to see what this shell can do", tone: 'dim' }),
+        ],
+      };
+  }
+}
+
+export interface Completion {
+  /** Full replacement input when the completion is unambiguous. */
+  value: string | null;
+  /** Candidates to print when there is more than one. */
+  options: string[];
+}
+
+function longestCommonPrefix(items: string[]): string {
+  let prefix = items[0];
+  for (const item of items.slice(1)) {
+    while (!item.startsWith(prefix)) {
+      prefix = prefix.slice(0, -1);
+    }
+  }
+  return prefix;
+}
+
+/**
+ * Tab completion for the live input line: command names for the first word,
+ * paths afterwards. `cd` only completes directories, because completing a file
+ * it will refuse to enter is just rude.
+ */
+export function complete(ctx: Pick<Context, 'root' | 'cwd'>, input: string): Completion {
+  const beforeCursor = input;
+  const tokens = beforeCursor.split(/\s+/);
+  const partial = tokens[tokens.length - 1];
+  const isCommand = tokens.length === 1;
+
+  let candidates: { insert: string; display: string }[];
+  if (isCommand) {
+    candidates = COMPLETABLE_COMMANDS.filter((c) => c.startsWith(partial)).map((c) => ({
+      insert: `${c} `,
+      display: c,
+    }));
+  } else {
+    const slash = partial.lastIndexOf('/');
+    const dirPart = slash === -1 ? '' : partial.slice(0, slash + 1);
+    const basePart = slash === -1 ? partial : partial.slice(slash + 1);
+    const dirNode = getNode(ctx.root, resolvePath(ctx.cwd, dirPart === '' ? '.' : dirPart));
+    if (!dirNode || dirNode.kind !== 'dir') {
+      return { value: null, options: [] };
+    }
+    const command = tokens[0];
+    candidates = visibleChildren(dirNode, basePart.startsWith('.'))
+      .filter((node) => node.name.startsWith(basePart))
+      .filter((node) => command !== 'cd' || node.kind === 'dir')
+      .map((node) => ({
+        insert: dirPart + node.name + (node.kind === 'dir' ? '/' : ' '),
+        display: node.kind === 'dir' ? `${node.name}/` : node.name,
+      }));
+  }
+
+  if (candidates.length === 0) {
+    return { value: null, options: [] };
+  }
+  const head = beforeCursor.slice(0, beforeCursor.length - partial.length);
+  if (candidates.length === 1) {
+    return { value: head + candidates[0].insert, options: [] };
+  }
+  const common = longestCommonPrefix(candidates.map((c) => c.insert));
+  const value = common.length > partial.length ? head + common : null;
+  return { value, options: candidates.map((c) => c.display) };
+}
+
+/** The window-bar title, e.g. `guest@mikhailbahdashych.me: ~/articles`. */
+export function windowTitle(host: string, cwd: string[]): string {
+  return `guest@${host}: ${formatCwd(cwd)}`;
+}

--- a/src/components/terminal/render.tsx
+++ b/src/components/terminal/render.tsx
@@ -1,0 +1,211 @@
+import Link from 'next/link';
+import type { ReactNode } from 'react';
+import type { Block, LsEntry } from './commands';
+import type { FileContent } from './vfs';
+
+/**
+ * Blocks → JSX. Anything with a site route becomes a real link, which is what
+ * keeps the boot transcript crawlable and the whole thing usable without
+ * typing a single command.
+ */
+
+function LsRow({ entry }: { entry: LsEntry }) {
+  const body = (
+    <>
+      <span className={entry.kind === 'dir' ? 'term-dir' : 'term-file'}>{entry.name}</span>
+      <span className="term-ls-title">{entry.title}</span>
+      <span className="term-ls-meta">{entry.meta}</span>
+    </>
+  );
+  if (entry.href) {
+    return (
+      <Link href={entry.href} className="term-ls-row" prefetch={false}>
+        {body}
+      </Link>
+    );
+  }
+  return <span className="term-ls-row">{body}</span>;
+}
+
+function FileView({ file }: { file: FileContent }) {
+  switch (file.kind) {
+    case 'readme':
+      return (
+        <div className="term-fileview">
+          <p className="term-title">{file.title}</p>
+          <p className="term-para">{file.intro}</p>
+          <p className="term-hint">featured work lives in articles/ and projects/</p>
+        </div>
+      );
+    case 'post': {
+      const { post } = file;
+      const meta =
+        post.type === 'article'
+          ? `${post.date} · ${post.readingTimeMin} min read`
+          : `${post.date.slice(0, 4)} · project`;
+      const href = post.type === 'article' ? `/blog/${post.slug}` : `/projects/${post.slug}`;
+      return (
+        <div className="term-fileview">
+          <p>
+            <span className="term-strong">{post.title}</span>
+            <span className="term-ls-meta">{`  ${meta}`}</span>
+          </p>
+          {post.tags.length > 0 && (
+            <p className="term-hint">{post.tags.map((tag) => `[${tag}]`).join(' ')}</p>
+          )}
+          <p className="term-para">{post.excerpt}</p>
+          <p>
+            <Link href={href} className="term-link" prefetch={false}>
+              → read it on the site
+            </Link>
+            {post.repoUrl && (
+              <>
+                {'   '}
+                <a
+                  className="term-link"
+                  href={post.repoUrl}
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  repo ↗
+                </a>
+              </>
+            )}
+          </p>
+        </div>
+      );
+    }
+    case 'about':
+      return (
+        <div className="term-fileview">
+          <p className="term-para">{file.para}</p>
+          <p>
+            <Link href="/about" className="term-link" prefetch={false}>
+              → the full story: /about
+            </Link>
+          </p>
+        </div>
+      );
+    case 'contact':
+      return (
+        <div className="term-fileview">
+          <p>
+            <span className="term-dim">email </span>
+            <a className="term-link" href={`mailto:${file.email}`}>
+              {file.email}
+            </a>
+          </p>
+          {file.links.map((link) => (
+            <p key={link.url}>
+              <span className="term-dim">{`${link.label.toLowerCase().padEnd(6)} `}</span>
+              <a className="term-link" href={link.url} rel="me noopener" target="_blank">
+                {link.url}
+              </a>
+            </p>
+          ))}
+        </div>
+      );
+    case 'plan':
+      return (
+        <div className="term-fileview">
+          <p>
+            1. build the blog{'          '}
+            <span className="term-ok">[done]</span>
+          </p>
+          <p>
+            2. write more{'              '}
+            <span className="term-amber">[in progress]</span>
+          </p>
+          <p>
+            3. touch grass{'             '}
+            <span className="term-dim">[blocked on 2]</span>
+          </p>
+        </div>
+      );
+  }
+}
+
+const PALETTE = [
+  '#1c1c1a',
+  '#e5534b',
+  '#57ab5a',
+  '#d29922',
+  '#6cb6ff',
+  '#b083f0',
+  '#39c5cf',
+  '#cfccc0',
+];
+
+function Neofetch({ art, rows }: { art: string[]; rows: [string, string][] }) {
+  return (
+    <div className="term-neofetch">
+      <pre className="term-neofetch-art" aria-hidden="true">
+        {art.join('\n')}
+      </pre>
+      <div className="term-neofetch-info">
+        {rows.map(([key, value]) => (
+          <p key={key}>
+            <span className="term-neofetch-key">{key.padEnd(8)}</span>
+            {value}
+          </p>
+        ))}
+        <p className="term-neofetch-palette" aria-hidden="true">
+          {PALETTE.map((color) => (
+            <span key={color} style={{ background: color }} />
+          ))}
+        </p>
+      </div>
+    </div>
+  );
+}
+
+export function renderBlock(block: Block, key: number): ReactNode {
+  switch (block.kind) {
+    case 'lines':
+      return (
+        <div key={key}>
+          {block.lines.map((line, i) => (
+            <p key={i} className={line.tone ? `term-${line.tone}` : undefined}>
+              {line.text === '' ? ' ' : line.text}
+            </p>
+          ))}
+        </div>
+      );
+    case 'ls':
+      return (
+        <div key={key} className="term-ls">
+          {block.entries.length === 0 && <p className="term-dim">(nothing here yet)</p>}
+          {block.entries.map((entry) => (
+            <LsRow key={entry.name} entry={entry} />
+          ))}
+          {block.footer && (
+            <Link href={block.footer.href} className="term-ls-footer term-link" prefetch={false}>
+              {block.footer.text} →
+            </Link>
+          )}
+        </div>
+      );
+    case 'file':
+      return <FileView key={key} file={block.file} />;
+    case 'neofetch':
+      return <Neofetch key={key} art={block.art} rows={block.rows} />;
+    case 'help':
+      return (
+        <div key={key} className="term-help">
+          {block.rows.map(([command, description]) => (
+            <p key={command}>
+              <span className="term-help-cmd">{command}</span>
+              <span className="term-dim">{description}</span>
+            </p>
+          ))}
+          <p className="term-hint">{block.footer}</p>
+        </div>
+      );
+    case 'completions':
+      return (
+        <p key={key} className="term-completions term-dim">
+          {block.items.join('   ')}
+        </p>
+      );
+  }
+}

--- a/src/components/terminal/terminal.test.ts
+++ b/src/components/terminal/terminal.test.ts
@@ -1,0 +1,350 @@
+import { describe, expect, it } from 'vitest';
+import { Block, Context, complete, listDir, run } from './commands';
+import { initialEntries } from './transcript';
+import {
+  TermPost,
+  TerminalData,
+  buildTerminalData,
+  buildVfs,
+  formatCwd,
+  getNode,
+  plainText,
+  resolvePath,
+  uptime,
+} from './vfs';
+
+function post(slug: string, type: 'article' | 'project', title: string): TermPost {
+  return {
+    slug,
+    type,
+    title,
+    excerpt: `About ${title}.`,
+    date: '2026-07-14',
+    readingTimeMin: 7,
+    tags: ['zeek', 'dns'],
+    repoUrl: type === 'project' ? `https://github.com/x/${slug}` : null,
+  };
+}
+
+const DATA: TerminalData = {
+  host: 'mikhailbahdashych.me',
+  heroTitle: 'Security engineering notes.',
+  heroIntro: 'Detection, cloud, and the occasional write-up.',
+  aboutPara: 'I work on detection engineering.',
+  location: 'Kraków, Poland',
+  email: 'hi@example.com',
+  socialLinks: [{ label: 'github', url: 'https://github.com/x' }],
+  role: 'Security Engineer · Acme',
+  uptime: '6y 5m',
+  topSkills: ['AWS', 'Zeek'],
+  articles: [
+    post('dns-tunnels', 'article', 'Detecting DNS tunnels'),
+    post('dns-exfil', 'article', 'DNS exfil notes'),
+  ],
+  projects: [post('zeek-kit', 'project', 'Zeek kit')],
+  articleTotal: 64,
+  projectTotal: 1,
+  lastActivityIso: '2026-08-01T12:00:00Z',
+};
+
+function ctx(overrides: Partial<Context> = {}): Context {
+  return {
+    data: DATA,
+    root: buildVfs(DATA),
+    cwd: [],
+    theme: 'dark',
+    history: [],
+    ...overrides,
+  };
+}
+
+function textOf(block: Block): string {
+  if (block.kind !== 'lines') {
+    throw new Error(`Expected a lines block, got '${block.kind}'`);
+  }
+  return block.lines.map((l) => l.text).join('\n');
+}
+
+describe('vfs paths', () => {
+  it('resolves relative, absolute, dot and dot-dot segments', () => {
+    expect(resolvePath(['articles'], 'dns-tunnels.md')).toEqual(['articles', 'dns-tunnels.md']);
+    expect(resolvePath(['articles'], '..')).toEqual([]);
+    expect(resolvePath(['articles'], '../projects/./zeek-kit.md')).toEqual([
+      'projects',
+      'zeek-kit.md',
+    ]);
+    expect(resolvePath(['articles'], '~')).toEqual([]);
+    expect(resolvePath(['articles'], '/projects')).toEqual(['projects']);
+    expect(resolvePath([], '../../..')).toEqual([]);
+  });
+
+  it('walks the tree and refuses to walk through files', () => {
+    const root = buildVfs(DATA);
+    expect(getNode(root, ['articles', 'dns-tunnels.md'])?.kind).toBe('file');
+    expect(getNode(root, ['articles', 'missing.md'])).toBeNull();
+    expect(getNode(root, ['README.md', 'nope'])).toBeNull();
+  });
+
+  it('hides dotfiles unless asked', () => {
+    const root = buildVfs(DATA);
+    const plain = listDir(root, false);
+    const all = listDir(root, true);
+    if (plain.kind !== 'ls' || all.kind !== 'ls') {
+      throw new Error('expected ls blocks');
+    }
+    expect(plain.entries.map((e) => e.name)).not.toContain('.plan');
+    expect(all.entries.map((e) => e.name)).toContain('.plan');
+  });
+
+  it('formats the cwd like a shell would', () => {
+    expect(formatCwd([])).toBe('~');
+    expect(formatCwd(['articles'])).toBe('~/articles');
+  });
+});
+
+describe('buildTerminalData', () => {
+  const about = {
+    fullName: 'Mikhail Bahdashych',
+    profileMd: 'I work on **detection**.\n\nSecond paragraph.',
+    location: 'Kraków, Poland',
+    contactEmail: 'hi@example.com',
+    seoTitle: null,
+    seoDescription: null,
+    avatarUrl: null,
+    positions: [
+      {
+        id: '1',
+        company: 'Acme',
+        companyUrl: null,
+        title: 'Security Engineer',
+        description: '',
+        location: 'Kraków',
+        logoUrl: null,
+        startDate: '2023-01-01',
+        endDate: null,
+        bullets: [],
+        skills: ['AWS', 'Zeek'],
+      },
+      {
+        id: '2',
+        company: 'Beta',
+        companyUrl: null,
+        title: 'Analyst',
+        description: '',
+        location: 'Warsaw',
+        logoUrl: null,
+        startDate: '2020-03-01',
+        endDate: '2022-12-31',
+        bullets: [],
+        skills: ['AWS'],
+      },
+    ],
+    education: [],
+    certifications: [],
+  };
+
+  it('derives role, career start, skills and totals', () => {
+    const data = buildTerminalData({
+      host: 'x.me',
+      config: {
+        heroTitle: 'T',
+        heroIntroMd: 'I',
+        socialLinks: [],
+        seoDefaultTitle: '',
+        seoDefaultDescription: '',
+        footerText: '',
+      },
+      about,
+      articles: { items: [], total: 0, page: 1, per: 10 },
+      projects: { items: [], total: 0, page: 1, per: 10 },
+      slugs: [
+        { slug: 'a', type: 'article', updatedAt: '2026-01-01T00:00:00Z' },
+        { slug: 'b', type: 'article', updatedAt: '2026-03-01T00:00:00Z' },
+        { slug: 'p', type: 'project', updatedAt: '2026-02-01T00:00:00Z' },
+      ],
+      now: Date.UTC(2026, 7, 9),
+    });
+    expect(data.role).toBe('Security Engineer · Acme');
+    // Career started 2020-03 (the older, closed position counts).
+    expect(data.uptime).toBe('6y 5m');
+    expect(data.topSkills).toEqual(['AWS', 'Zeek']);
+    expect(data.articleTotal).toBe(2);
+    expect(data.projectTotal).toBe(1);
+    expect(data.lastActivityIso).toBe('2026-03-01T00:00:00Z');
+    expect(data.aboutPara).toBe('I work on detection.');
+  });
+
+  it('strips markdown links but keeps their text', () => {
+    expect(plainText('See [the repo](https://x) and ![img](y).')).toBe('See the repo and img.');
+  });
+});
+
+describe('run', () => {
+  it('lists the home directory with the curated order', () => {
+    const [block] = run(ctx(), 'ls').blocks;
+    if (block.kind !== 'ls') {
+      throw new Error('expected ls');
+    }
+    expect(block.entries.map((e) => e.name)).toEqual([
+      'README.md',
+      'about.md',
+      'contact.md',
+      'articles/',
+      'projects/',
+    ]);
+  });
+
+  it('links archive footers only when there is more than what is listed', () => {
+    const result = run(ctx(), 'ls articles');
+    const [articles] = result.blocks;
+    if (articles.kind !== 'ls') {
+      throw new Error('expected ls');
+    }
+    expect(articles.footer).toEqual({ text: '+ 62 more in the archive', href: '/blog' });
+
+    const [projects] = run(ctx(), 'ls projects').blocks;
+    if (projects.kind !== 'ls') {
+      throw new Error('expected ls');
+    }
+    expect(projects.footer).toBeNull();
+  });
+
+  it('rejects unknown flags the way ls would', () => {
+    expect(textOf(run(ctx(), 'ls -z').blocks[0])).toBe("ls: invalid option -- 'z'");
+    const hidden = run(ctx(), 'ls -la').blocks[0];
+    if (hidden.kind !== 'ls') {
+      throw new Error('expected ls');
+    }
+    expect(hidden.entries.map((e) => e.name)).toContain('.plan');
+  });
+
+  it('changes directory, errors on files and missing paths', () => {
+    expect(run(ctx(), 'cd articles').cwd).toEqual(['articles']);
+    expect(textOf(run(ctx(), 'cd README.md').blocks[0])).toBe('cd: not a directory: README.md');
+    expect(textOf(run(ctx(), 'cd nowhere').blocks[0])).toBe(
+      'cd: no such file or directory: nowhere',
+    );
+    expect(run(ctx({ cwd: ['articles'] }), 'cd').cwd).toEqual([]);
+  });
+
+  it('prints a fake but honest pwd', () => {
+    expect(textOf(run(ctx({ cwd: ['articles'] }), 'pwd').blocks[0])).toBe('/home/guest/articles');
+  });
+
+  it('cats posts from any directory', () => {
+    const [block] = run(ctx({ cwd: ['projects'] }), 'cat ../articles/dns-tunnels.md').blocks;
+    if (block.kind !== 'file' || block.file.kind !== 'post') {
+      throw new Error('expected a post file');
+    }
+    expect(block.file.post.title).toBe('Detecting DNS tunnels');
+    expect(textOf(run(ctx(), 'cat articles').blocks[0])).toBe('cat: articles: Is a directory');
+  });
+
+  it('opens posts and directories that have a home on the site', () => {
+    expect(run(ctx(), 'open articles/dns-tunnels.md').effect).toEqual({
+      kind: 'navigate',
+      href: '/blog/dns-tunnels',
+    });
+    expect(run(ctx(), 'open projects').effect).toEqual({ kind: 'navigate', href: '/projects' });
+    expect(run(ctx(), 'open about.md').effect).toEqual({ kind: 'navigate', href: '/about' });
+    expect(run(ctx(), 'open README.md').effect).toBeUndefined();
+  });
+
+  it('toggles and sets the theme', () => {
+    expect(run(ctx({ theme: 'dark' }), 'theme').effect).toEqual({ kind: 'theme', mode: 'light' });
+    expect(run(ctx({ theme: 'light' }), 'theme').effect).toEqual({ kind: 'theme', mode: 'dark' });
+    expect(run(ctx(), 'theme dark').effect).toEqual({ kind: 'theme', mode: 'dark' });
+    expect(run(ctx(), 'theme blue').effect).toBeUndefined();
+  });
+
+  it('computes uptime in years and months', () => {
+    expect(uptime('2020-03-01', Date.UTC(2026, 7, 9))).toBe('6y 5m');
+    expect(uptime('2026-08-01', Date.UTC(2026, 7, 9))).toBe('0y 0m');
+  });
+
+  it('builds neofetch rows from real data', () => {
+    const [block] = run(ctx(), 'neofetch').blocks;
+    if (block.kind !== 'neofetch') {
+      throw new Error('expected neofetch');
+    }
+    const rows = Object.fromEntries(block.rows);
+    expect(rows.user).toBe('guest@mikhailbahdashych.me');
+    expect(rows.role).toBe('Security Engineer · Acme');
+    expect(rows.uptime).toBe('6y 5m');
+    expect(rows.posts).toBe('64 articles · 1 projects');
+    // No theme row: the boot transcript pre-runs this block server-side,
+    // where the visitor's theme is unknowable.
+    expect(rows.theme).toBeUndefined();
+    expect(run(ctx(), 'fastfetch').blocks[0].kind).toBe('neofetch');
+  });
+
+  it('keeps the eggs in character', () => {
+    expect(textOf(run(ctx(), 'sudo make me a sandwich').blocks[0])).toContain('not in the sudoers');
+    expect(textOf(run(ctx(), 'rm -rf /').blocks[0])).toContain('read-only file system');
+    expect(textOf(run(ctx(), 'vim').blocks[0])).toContain('no editors');
+    expect(run(ctx(), 'exit').effect).toEqual({ kind: 'exit' });
+    expect(run(ctx(), 'clear').effect).toEqual({ kind: 'clear' });
+  });
+
+  it('handles echo, whoami, history and nonsense', () => {
+    expect(textOf(run(ctx(), 'echo hello there').blocks[0])).toBe('hello there');
+    expect(textOf(run(ctx(), 'whoami').blocks[0])).toContain('guest');
+    expect(textOf(run(ctx({ history: ['ls', 'help'] }), 'history').blocks[0])).toContain('help');
+    expect(textOf(run(ctx(), 'frobnicate').blocks[0])).toBe('zsh: command not found: frobnicate');
+    expect(run(ctx(), '   ').blocks).toEqual([]);
+  });
+});
+
+describe('complete', () => {
+  it('completes commands on the first word', () => {
+    expect(complete(ctx(), 'neo')).toEqual({ value: 'neofetch ', options: [] });
+    const many = complete(ctx(), 'c');
+    expect(many.options).toEqual(['cat', 'cd', 'clear']);
+    expect(many.value).toBeNull();
+  });
+
+  it('completes paths, appending / to directories', () => {
+    expect(complete(ctx(), 'cat R')).toEqual({ value: 'cat README.md ', options: [] });
+    expect(complete(ctx(), 'ls art')).toEqual({ value: 'ls articles/', options: [] });
+    expect(complete(ctx(), 'cat articles/dns-t')).toEqual({
+      value: 'cat articles/dns-tunnels.md ',
+      options: [],
+    });
+  });
+
+  it('extends to the longest common prefix and lists candidates', () => {
+    // 'dns-tunnels.md' and 'dns-exfil.md' share 'dns-': the input grows to
+    // the shared prefix while both stay on offer.
+    const extended = complete(ctx(), 'cat articles/dns');
+    expect(extended.value).toBe('cat articles/dns-');
+    expect(extended.options).toEqual(['dns-tunnels.md', 'dns-exfil.md']);
+
+    // 'about.md' vs 'articles/' share only the 'a' already typed.
+    const ambiguous = complete(ctx(), 'cat a');
+    expect(ambiguous.value).toBeNull();
+    expect(ambiguous.options).toEqual(['about.md', 'articles/']);
+  });
+
+  it('only offers directories to cd', () => {
+    const result = complete(ctx(), 'cd ');
+    expect(result.options).toEqual(['articles/', 'projects/']);
+  });
+
+  it('offers dotfiles only when the prefix asks for them', () => {
+    expect(complete(ctx(), 'cat .p')).toEqual({ value: 'cat .plan ', options: [] });
+  });
+});
+
+describe('initialEntries', () => {
+  it('boots small: a motd line and a pre-run neofetch', () => {
+    const entries = initialEntries(DATA);
+    expect(entries.map((e) => e.prompt?.text)).toEqual([undefined, 'neofetch']);
+    expect(textOf(entries[0].blocks[0])).toContain('Last login: 2026-08-01');
+    expect(entries[1].blocks[0].kind).toBe('neofetch');
+  });
+
+  it('skips the motd when nothing has ever been published', () => {
+    const entries = initialEntries({ ...DATA, lastActivityIso: null });
+    expect(entries.map((e) => e.prompt?.text)).toEqual(['neofetch']);
+  });
+});

--- a/src/components/terminal/terminal.tsx
+++ b/src/components/terminal/terminal.tsx
@@ -1,0 +1,270 @@
+'use client';
+
+import { useRouter } from 'next/navigation';
+import { useEffect, useMemo, useRef, useState } from 'react';
+import type { CSSProperties, ChangeEvent, KeyboardEvent, MouseEvent, SyntheticEvent } from 'react';
+import { complete, run, windowTitle } from './commands';
+import type { Effect } from './commands';
+import { renderBlock } from './render';
+import { initialEntries } from './transcript';
+import type { Entry } from './transcript';
+import { TerminalData, buildVfs, formatCwd } from './vfs';
+
+/**
+ * A little shell between the hero and the featured sections. The boot
+ * transcript (motd + neofetch) is server-rendered from props; after hydration
+ * the prompt is a live zsh-flavoured toy over the same data, scrolling inside
+ * its own window. All command logic lives in ./commands — this component only
+ * owns input state, focus, history and effects.
+ */
+
+/** Short hostname for the prompt; the FQDN stays in the window title. */
+const PROMPT_HOST = 'blog';
+
+function Prompt({ cwd }: { cwd: string }) {
+  return (
+    <span className="term-prompt">
+      <span className="term-p-user">guest@{PROMPT_HOST}</span>{' '}
+      <span className="term-p-path">{cwd}</span> <span className="term-p-sym">$</span>{' '}
+    </span>
+  );
+}
+
+function currentTheme(): 'dark' | 'light' {
+  return document.documentElement.getAttribute('data-theme') === 'dark' ? 'dark' : 'light';
+}
+
+export function Terminal({ data }: { data: TerminalData }) {
+  const router = useRouter();
+  const root = useMemo(() => buildVfs(data), [data]);
+  const boot = useMemo(() => initialEntries(data), [data]);
+
+  const [entries, setEntries] = useState<Entry[]>(boot);
+  const [cwd, setCwd] = useState<string[]>([]);
+  const [input, setInput] = useState('');
+  const [caret, setCaret] = useState(0);
+  const [focused, setFocused] = useState(false);
+  const [interacted, setInteracted] = useState(false);
+
+  const inputRef = useRef<HTMLInputElement>(null);
+  const bodyRef = useRef<HTMLDivElement>(null);
+  const seq = useRef(0);
+  const hist = useRef<{ list: string[]; index: number | null; draft: string }>({
+    list: [],
+    index: null,
+    draft: '',
+  });
+
+  /**
+   * The input is uncontrolled — the DOM owns the value, the mirror follows it
+   * through state. Anything that can write an input (typing, IME suggestions,
+   * password managers, test drivers) then stays in sync by construction; a
+   * controlled input desyncs the moment a value arrives without an onChange.
+   */
+  const setLine = (value: string) => {
+    const el = inputRef.current;
+    if (el) {
+      el.value = value;
+      el.setSelectionRange(value.length, value.length);
+    }
+    setInput(value);
+    setCaret(value.length);
+  };
+
+  const append = (entry: Omit<Entry, 'id'>) => {
+    seq.current += 1;
+    const id = `live-${seq.current}`;
+    setEntries((prev) => [...prev, { id, ...entry }]);
+  };
+
+  const applyEffect = (effect: Effect) => {
+    switch (effect.kind) {
+      case 'clear':
+        setEntries([]);
+        break;
+      case 'navigate':
+        router.push(effect.href);
+        break;
+      case 'theme':
+        // Same contract as the header toggle: attribute drives CSS, storage
+        // makes it stick across visits.
+        document.documentElement.setAttribute('data-theme', effect.mode);
+        localStorage.setItem('theme', effect.mode);
+        break;
+      case 'exit':
+        inputRef.current?.blur();
+        break;
+    }
+  };
+
+  const runLine = (raw: string) => {
+    const prompt = { cwd: formatCwd(cwd), text: raw };
+    const trimmed = raw.trim();
+    if (trimmed !== '' && trimmed !== hist.current.list[hist.current.list.length - 1]) {
+      hist.current.list.push(trimmed);
+    }
+    hist.current.index = null;
+
+    const result = run({ data, root, cwd, theme: currentTheme(), history: hist.current.list }, raw);
+    if (result.effect?.kind === 'clear') {
+      setEntries([]);
+    } else {
+      append({ prompt, blocks: result.blocks });
+      if (result.effect) {
+        applyEffect(result.effect);
+      }
+    }
+    if (result.cwd) {
+      setCwd(result.cwd);
+    }
+    setLine('');
+  };
+
+  const onKeyDown = (event: KeyboardEvent<HTMLInputElement>) => {
+    const h = hist.current;
+    // The DOM value, not React state: at keydown time it is the one truth.
+    const line = event.currentTarget.value;
+    if (event.key === 'Enter') {
+      runLine(line);
+    } else if (event.key === 'Tab') {
+      event.preventDefault();
+      const completion = complete({ root, cwd }, line);
+      if (completion.value !== null) {
+        setLine(completion.value);
+      }
+      if (completion.options.length > 1) {
+        append({ blocks: [{ kind: 'completions', items: completion.options }] });
+      }
+    } else if (event.key === 'ArrowUp') {
+      event.preventDefault();
+      if (h.list.length === 0) {
+        return;
+      }
+      if (h.index === null) {
+        h.draft = line;
+        h.index = h.list.length - 1;
+      } else if (h.index > 0) {
+        h.index -= 1;
+      }
+      setLine(h.list[h.index]);
+    } else if (event.key === 'ArrowDown') {
+      event.preventDefault();
+      if (h.index === null) {
+        return;
+      }
+      h.index += 1;
+      if (h.index >= h.list.length) {
+        h.index = null;
+        setLine(h.draft);
+      } else {
+        setLine(h.list[h.index]);
+      }
+    } else if (event.key === 'c' && event.ctrlKey) {
+      event.preventDefault();
+      append({ prompt: { cwd: formatCwd(cwd), text: `${line}^C` }, blocks: [] });
+      hist.current.index = null;
+      setLine('');
+    } else if (event.key === 'l' && event.ctrlKey) {
+      event.preventDefault();
+      setEntries([]);
+    }
+  };
+
+  const syncFromInput = (
+    event: ChangeEvent<HTMLInputElement> | SyntheticEvent<HTMLInputElement>,
+  ) => {
+    const el = event.currentTarget;
+    setInput(el.value);
+    setCaret(el.selectionStart ?? el.value.length);
+  };
+
+  // Clicking anywhere in the window focuses the prompt — unless the click is
+  // a link doing its job, or the visitor is selecting text to copy.
+  const onSurfaceClick = (event: MouseEvent<HTMLElement>) => {
+    if ((event.target as HTMLElement).closest('a')) {
+      return;
+    }
+    const selection = window.getSelection();
+    if (selection && !selection.isCollapsed) {
+      return;
+    }
+    inputRef.current?.focus({ preventScroll: true });
+  };
+
+  // The terminal scrolls internally; keep the prompt pinned to the bottom as
+  // output grows. Scoped to the window's own scrollbox so running a command
+  // never moves the page — and skipped until first interaction, so the boot
+  // content is read from the top.
+  useEffect(() => {
+    const body = bodyRef.current;
+    if (!interacted || !body) {
+      return;
+    }
+    const reduced = matchMedia('(prefers-reduced-motion: reduce)').matches;
+    body.scrollTo({ top: body.scrollHeight, behavior: reduced ? 'auto' : 'smooth' });
+  }, [entries, interacted]);
+
+  return (
+    // --i 2: the reveal stagger slot after the hero title (0) and intro (1).
+    <section
+      className="term reveal"
+      style={{ '--i': 2 } as CSSProperties}
+      aria-label="Interactive terminal"
+      onClick={onSurfaceClick}
+    >
+      <div className="term-bar">
+        <span className="term-dots" aria-hidden="true">
+          <span />
+          <span />
+          <span />
+        </span>
+        <span className="term-bar-title">{windowTitle(data.host, cwd)}</span>
+      </div>
+      <div className="term-body" ref={bodyRef}>
+        <div role="log" aria-live="polite">
+          {entries.map((entry) => (
+            <div key={entry.id} className="term-entry">
+              {entry.prompt && (
+                <p className="term-echo">
+                  <Prompt cwd={entry.prompt.cwd} />
+                  {entry.prompt.text}
+                </p>
+              )}
+              {entry.blocks.map((block, i) => renderBlock(block, i))}
+            </div>
+          ))}
+        </div>
+        <div className={`term-live${focused ? ' focused' : ''}`}>
+          <Prompt cwd={formatCwd(cwd)} />
+          <span className="term-mirror">
+            {input.slice(0, caret)}
+            <span className="term-cursor">{input[caret] ?? ' '}</span>
+            {input.slice(caret + 1)}
+            {!interacted && input === '' && (
+              <span className="term-placeholder">try &apos;help&apos;</span>
+            )}
+          </span>
+          <input
+            ref={inputRef}
+            className="term-input"
+            defaultValue=""
+            onChange={syncFromInput}
+            onSelect={syncFromInput}
+            onKeyDown={onKeyDown}
+            onFocus={() => {
+              setFocused(true);
+              setInteracted(true);
+            }}
+            onBlur={() => setFocused(false)}
+            aria-label="Terminal input — type 'help' for available commands"
+            autoCapitalize="off"
+            autoComplete="off"
+            autoCorrect="off"
+            spellCheck={false}
+            enterKeyHint="go"
+          />
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/components/terminal/transcript.ts
+++ b/src/components/terminal/transcript.ts
@@ -1,0 +1,50 @@
+import { Block, neofetchBlock } from './commands';
+import { TerminalData } from './vfs';
+
+/**
+ * One rendered exchange: an optional echoed prompt line and its output.
+ * The boot transcript and live commands share this shape, so the renderer
+ * never knows which is which.
+ */
+export interface Entry {
+  id: string;
+  prompt?: { cwd: string; text: string };
+  blocks: Block[];
+}
+
+/**
+ * What the terminal shows before anyone types. The terminal is a toy beside
+ * the real content now, so the boot stays small: a motd line and a pre-run
+ * `neofetch`. Pure function of the data — no clock, no randomness — so the
+ * server and the client render it identically.
+ */
+export function initialEntries(data: TerminalData): Entry[] {
+  const motd: Entry[] =
+    data.lastActivityIso === null
+      ? []
+      : [
+          {
+            id: 'boot-motd',
+            blocks: [
+              {
+                kind: 'lines',
+                lines: [
+                  {
+                    text: `Last login: ${data.lastActivityIso.slice(0, 10)} from 127.0.0.1`,
+                    tone: 'dim',
+                  },
+                ],
+              },
+            ],
+          },
+        ];
+
+  return [
+    ...motd,
+    {
+      id: 'boot-neofetch',
+      prompt: { cwd: '~', text: 'neofetch' },
+      blocks: [neofetchBlock(data)],
+    },
+  ];
+}

--- a/src/components/terminal/vfs.ts
+++ b/src/components/terminal/vfs.ts
@@ -1,0 +1,273 @@
+import type { About, PostList, SiteConfig, SlugEntry } from '@/lib/types';
+import { fmtDate } from '@/lib/format';
+
+/**
+ * The home-page terminal's world: a tiny read-only filesystem built from the
+ * same data the old home page rendered as sections. Everything in this module
+ * is pure and serializable — the server builds `TerminalData`, the client
+ * builds the tree from it, and the command layer only ever walks the tree.
+ */
+
+export interface TermPost {
+  slug: string;
+  type: 'article' | 'project';
+  title: string;
+  excerpt: string;
+  /** Preformatted YYYY-MM-DD so no date logic runs on the client. */
+  date: string;
+  readingTimeMin: number;
+  tags: string[];
+  repoUrl: string | null;
+}
+
+export interface TerminalData {
+  /** Hostname only, e.g. 'mikhailbahdashych.me' — used in prompt and titles. */
+  host: string;
+  heroTitle: string;
+  heroIntro: string;
+  aboutPara: string;
+  location: string;
+  email: string;
+  socialLinks: { label: string; url: string }[];
+  /** 'Title · Company' of the current position; null when no positions exist. */
+  role: string | null;
+  /**
+   * "6y 5m" since the earliest position started; null when no positions
+   * exist. Precomputed on the server so the boot transcript needs no clock —
+   * the client would otherwise hydrate a different string across a month
+   * boundary.
+   */
+  uptime: string | null;
+  topSkills: string[];
+  articles: TermPost[];
+  projects: TermPost[];
+  articleTotal: number;
+  projectTotal: number;
+  /** Most recent content update — powers the "Last login" motd line. */
+  lastActivityIso: string | null;
+}
+
+export type FileContent =
+  | { kind: 'readme'; title: string; intro: string }
+  | { kind: 'post'; post: TermPost }
+  | { kind: 'about'; para: string }
+  | { kind: 'contact'; email: string; links: { label: string; url: string }[] }
+  | { kind: 'plan' };
+
+export interface VfsFile {
+  kind: 'file';
+  name: string;
+  hidden?: boolean;
+  content: FileContent;
+  /** Site route `open` navigates to; null means there is nowhere to go. */
+  href: string | null;
+}
+
+export interface VfsDir {
+  kind: 'dir';
+  name: string;
+  hidden?: boolean;
+  children: VfsNode[];
+  href: string | null;
+  /** How many published posts exist beyond the featured ones listed here. */
+  extraTotal: number;
+}
+
+export type VfsNode = VfsFile | VfsDir;
+
+/** Markdown → plain text, good enough for a one-paragraph terminal bio. */
+export function plainText(md: string): string {
+  return md
+    .replace(/!\[([^\]]*)\]\([^)]*\)/g, '$1')
+    .replace(/\[([^\]]+)\]\([^)]*\)/g, '$1')
+    .replace(/[*_`#>]/g, '')
+    .trim();
+}
+
+function toTermPost(post: PostList['items'][number]): TermPost {
+  return {
+    slug: post.slug,
+    type: post.type,
+    title: post.title,
+    excerpt: post.excerpt,
+    date: fmtDate(post.publishedAt),
+    readingTimeMin: post.readingTimeMin,
+    tags: post.tags,
+    repoUrl: post.repoUrl,
+  };
+}
+
+/** 'Title · Company' of the open-ended position, else the most recent one. */
+function currentRole(about: About): string | null {
+  const sorted = [...about.positions].sort((a, b) => b.startDate.localeCompare(a.startDate));
+  const open = sorted.find((p) => p.endDate === null);
+  const position = open ?? sorted[0];
+  if (!position) {
+    return null;
+  }
+  return `${position.title} · ${position.company}`;
+}
+
+/** "3y 4m" from the earliest position start to `now`. */
+export function uptime(startIso: string, now: number): string {
+  const start = new Date(`${startIso.slice(0, 10)}T00:00:00Z`);
+  const months = Math.max(
+    0,
+    (new Date(now).getUTCFullYear() - start.getUTCFullYear()) * 12 +
+      (new Date(now).getUTCMonth() - start.getUTCMonth()),
+  );
+  return `${Math.floor(months / 12)}y ${months % 12}m`;
+}
+
+/** Most frequent skills across all positions, ties broken by first appearance. */
+function topSkills(about: About, limit: number): string[] {
+  const counts = new Map<string, number>();
+  for (const position of about.positions) {
+    for (const skill of position.skills) {
+      counts.set(skill, (counts.get(skill) ?? 0) + 1);
+    }
+  }
+  return [...counts.entries()]
+    .sort((a, b) => b[1] - a[1])
+    .slice(0, limit)
+    .map(([skill]) => skill);
+}
+
+export function buildTerminalData(input: {
+  host: string;
+  config: SiteConfig;
+  about: About;
+  articles: PostList;
+  projects: PostList;
+  slugs: SlugEntry[];
+  now: number;
+}): TerminalData {
+  const { host, config, about, articles, projects, slugs, now } = input;
+  const starts = about.positions.map((p) => p.startDate).sort();
+  const updates = slugs.map((s) => s.updatedAt).sort();
+
+  return {
+    host,
+    heroTitle: config.heroTitle,
+    heroIntro: config.heroIntroMd,
+    aboutPara: plainText(about.profileMd.split(/\n\s*\n/)[0]),
+    location: about.location,
+    email: about.contactEmail,
+    socialLinks: config.socialLinks,
+    role: currentRole(about),
+    uptime: starts.length === 0 ? null : uptime(starts[0], now),
+    topSkills: topSkills(about, 4),
+    articles: articles.items.map(toTermPost),
+    projects: projects.items.map(toTermPost),
+    articleTotal: slugs.filter((s) => s.type === 'article').length,
+    projectTotal: slugs.filter((s) => s.type === 'project').length,
+    lastActivityIso: updates[updates.length - 1] ?? null,
+  };
+}
+
+export function postHref(post: TermPost): string {
+  return post.type === 'article' ? `/blog/${post.slug}` : `/projects/${post.slug}`;
+}
+
+function postFile(post: TermPost): VfsFile {
+  return {
+    kind: 'file',
+    name: `${post.slug}.md`,
+    content: { kind: 'post', post },
+    href: postHref(post),
+  };
+}
+
+export function buildVfs(data: TerminalData): VfsDir {
+  return {
+    kind: 'dir',
+    name: '~',
+    href: null,
+    extraTotal: 0,
+    children: [
+      {
+        kind: 'file',
+        name: 'README.md',
+        content: { kind: 'readme', title: data.heroTitle, intro: data.heroIntro },
+        href: null,
+      },
+      {
+        kind: 'file',
+        name: 'about.md',
+        content: { kind: 'about', para: data.aboutPara },
+        href: '/about',
+      },
+      {
+        kind: 'file',
+        name: 'contact.md',
+        content: { kind: 'contact', email: data.email, links: data.socialLinks },
+        href: null,
+      },
+      {
+        kind: 'dir',
+        name: 'articles',
+        href: '/blog',
+        extraTotal: Math.max(0, data.articleTotal - data.articles.length),
+        children: data.articles.map(postFile),
+      },
+      {
+        kind: 'dir',
+        name: 'projects',
+        href: '/projects',
+        extraTotal: Math.max(0, data.projectTotal - data.projects.length),
+        children: data.projects.map(postFile),
+      },
+      {
+        kind: 'file',
+        name: '.plan',
+        hidden: true,
+        content: { kind: 'plan' },
+        href: null,
+      },
+    ],
+  };
+}
+
+/**
+ * Lexical path resolution — `~` and `/` both mean home, `..` walks up and
+ * stops there, `.` is a no-op. Returns the path as segments; whether anything
+ * lives at that path is `getNode`'s business.
+ */
+export function resolvePath(cwd: string[], raw: string): string[] {
+  const absolute = raw.startsWith('~') || raw.startsWith('/');
+  const path = absolute ? [] : [...cwd];
+  for (const segment of raw.split('/')) {
+    if (segment === '' || segment === '.' || segment === '~') {
+      continue;
+    }
+    if (segment === '..') {
+      path.pop();
+    } else {
+      path.push(segment);
+    }
+  }
+  return path;
+}
+
+export function getNode(root: VfsDir, path: string[]): VfsNode | null {
+  let node: VfsNode = root;
+  for (const segment of path) {
+    if (node.kind !== 'dir') {
+      return null;
+    }
+    const child: VfsNode | undefined = node.children.find((c) => c.name === segment);
+    if (!child) {
+      return null;
+    }
+    node = child;
+  }
+  return node;
+}
+
+export function visibleChildren(dir: VfsDir, showHidden: boolean): VfsNode[] {
+  return dir.children.filter((child) => showHidden || child.hidden !== true);
+}
+
+export function formatCwd(path: string[]): string {
+  return path.length === 0 ? '~' : `~/${path.join('/')}`;
+}

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -163,6 +163,30 @@ h3 {
 
 /* --- Home ------------------------------------------------------------------- */
 
+/* Home is the one wide page: hero + terminal on the left, featured listings on
+ * the right. The shell only stretches when it holds the home grid, so every
+ * other page keeps the 716px column. Browsers without :has() simply keep home
+ * narrow too — the grid below collapses to one column inside it. */
+.shell:has(.home-grid) {
+  max-width: 1180px;
+}
+
+.home-grid {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
+  column-gap: 72px;
+  align-items: start;
+}
+
+/* First label on the right sits level with the hero title's first line. */
+.home-side {
+  margin-top: 62px;
+}
+
+.home-side .home-section:first-child {
+  margin-top: 0;
+}
+
 .hero-title {
   margin-top: 52px;
   font-family: var(--font-serif);
@@ -173,8 +197,26 @@ h3 {
   color: var(--text);
 }
 
-.hero-intro {
+/* Intro paragraph with the resident ASCII cat keeping watch beside it. */
+.hero-lede {
+  display: flex;
+  align-items: flex-start;
+  gap: 20px;
   margin-top: 20px;
+}
+
+.hero-pet {
+  flex: none;
+  margin: 0;
+  font-family: var(--font-mono);
+  font-size: 11px;
+  line-height: 1.4;
+  color: var(--secondary);
+  white-space: pre;
+  user-select: none;
+}
+
+.hero-intro {
   font-size: 14px;
   line-height: 1.7;
   color: var(--secondary);
@@ -187,6 +229,24 @@ h3 {
 
 .home-section + .home-section {
   margin-top: 40px;
+}
+
+/* Below the split point, home reads like every other page again:
+ * hero → terminal → featured, in one 716px column. */
+@media (max-width: 1023px) {
+  .home-grid {
+    display: block;
+    max-width: 716px;
+    margin-inline: auto;
+  }
+
+  .home-side {
+    margin-top: 0;
+  }
+
+  .home-side .home-section:first-child {
+    margin-top: 44px;
+  }
 }
 
 .section-row {

--- a/src/styles/terminal.css
+++ b/src/styles/terminal.css
@@ -1,0 +1,411 @@
+/* --- Home-page terminal ------------------------------------------------------
+ * One window card between the hero and the featured sections. It follows the
+ * site theme — charcoal terminal in dark mode, warm paper terminal in light —
+ * with its palette leaning on the site tokens (--success, --danger, --muted)
+ * where they fit, so a future token change carries through. Green prompt,
+ * amber paths in both.
+ */
+
+:root[data-theme='dark'] .term {
+  --t-bg: var(--code-bg);
+  --t-text: #d3d0c4;
+  --t-strong: #eae8df;
+  --t-dim: #837e70;
+  --t-amber: #d29922;
+  --t-hover: rgba(255, 255, 255, 0.045);
+  --t-chrome: rgba(255, 255, 255, 0.04);
+  --t-chrome-border: rgba(255, 255, 255, 0.06);
+}
+
+:root[data-theme='light'] .term {
+  --t-bg: var(--wash);
+  --t-text: var(--body);
+  --t-strong: var(--text);
+  --t-dim: var(--muted);
+  --t-amber: #9a6700;
+  --t-hover: rgba(28, 28, 26, 0.05);
+  --t-chrome: rgba(28, 28, 26, 0.035);
+  --t-chrome-border: rgba(28, 28, 26, 0.07);
+}
+
+.term {
+  --t-ok: var(--success);
+  --t-err: var(--danger);
+
+  margin-top: 40px;
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  background: var(--t-bg);
+  overflow: hidden;
+  cursor: text;
+}
+
+/* --- Window chrome ----------------------------------------------------------- */
+
+.term-bar {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 10px 14px;
+  background: var(--t-chrome);
+  border-bottom: 1px solid var(--t-chrome-border);
+}
+
+.term-dots {
+  display: inline-flex;
+  gap: 7px;
+}
+
+.term-dots span {
+  width: 11px;
+  height: 11px;
+  border-radius: 50%;
+  opacity: 0.85;
+}
+
+.term-dots span:nth-child(1) {
+  background: #e5534b;
+}
+
+.term-dots span:nth-child(2) {
+  background: #d29922;
+}
+
+.term-dots span:nth-child(3) {
+  background: #57ab5a;
+}
+
+.term-bar-title {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--t-dim);
+  letter-spacing: 0.02em;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+/* --- Body -------------------------------------------------------------------- */
+
+/* A toy window, not the page: it holds a fixed height and scrolls inside.
+ * The boot content (motd + neofetch) is sized to fit without a scrollbar. */
+.term-body {
+  max-height: min(400px, 60vh);
+  overflow-y: auto;
+  padding: 16px 18px 20px;
+  font-family: var(--font-mono);
+  font-size: 13px;
+  line-height: 1.75;
+  color: var(--t-text);
+  scrollbar-width: thin;
+  scrollbar-color: var(--t-dim) transparent;
+}
+
+/* In the two-column home layout the window stands taller against the listing
+ * column — the space under the prompt is just an idle screen, like any
+ * terminal that has not filled up yet. */
+@media (min-width: 1024px) {
+  .term-body {
+    min-height: 420px;
+    max-height: min(520px, 65vh);
+  }
+}
+
+.term-body p {
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+}
+
+.term-entry {
+  margin-bottom: 14px;
+}
+
+.term-echo {
+  color: var(--t-strong);
+}
+
+.term-prompt {
+  user-select: none;
+}
+
+.term-p-user {
+  color: var(--t-ok);
+}
+
+.term-p-path {
+  color: var(--t-amber);
+}
+
+.term-p-sym {
+  color: var(--t-dim);
+}
+
+.term-default {
+  color: var(--t-text);
+}
+
+.term-dim,
+.term-hint {
+  color: var(--t-dim);
+}
+
+.term-error {
+  color: var(--t-err);
+}
+
+.term-ok {
+  color: var(--t-ok);
+}
+
+.term-amber {
+  color: var(--t-amber);
+}
+
+.term-strong {
+  color: var(--t-strong);
+  font-weight: 700;
+}
+
+/* The h1 lives inside `cat README.md` output; it is a terminal line, not the
+ * serif hero — but it still carries the page's one h1 for crawlers. */
+.term-title {
+  font-family: var(--font-mono);
+  font-size: 15px;
+  font-weight: 700;
+  line-height: 1.5;
+  color: var(--t-strong);
+  margin: 0 0 6px;
+}
+
+.term-para {
+  color: var(--t-text);
+  max-width: 60ch;
+}
+
+.term-fileview {
+  padding: 2px 0;
+}
+
+.term-link {
+  color: var(--t-text);
+  text-decoration: underline;
+  text-underline-offset: 3px;
+  text-decoration-color: var(--t-dim);
+}
+
+.term-link:hover {
+  color: var(--t-strong);
+  text-decoration-color: var(--t-strong);
+}
+
+/* --- ls output --------------------------------------------------------------- */
+
+.term-ls {
+  display: block;
+}
+
+.term-ls-row {
+  display: grid;
+  grid-template-columns: minmax(12ch, max-content) minmax(0, 1fr) auto;
+  gap: 0 16px;
+  align-items: baseline;
+  padding: 1px 6px;
+  margin: 0 -6px;
+  border-radius: 4px;
+  color: var(--t-text);
+  text-decoration: none;
+}
+
+/* Filenames are slugs and slugs can be long; one line each, ellipsized, like
+ * a terminal column that ran out of patience. */
+.term-ls-row .term-file,
+.term-ls-row .term-dir {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 34ch;
+}
+
+a.term-ls-row:hover {
+  background: var(--t-hover);
+}
+
+a.term-ls-row:hover .term-file,
+a.term-ls-row:hover .term-dir {
+  text-decoration: underline;
+  text-underline-offset: 3px;
+}
+
+.term-dir {
+  color: var(--t-amber);
+  font-weight: 500;
+}
+
+.term-file {
+  color: var(--t-text);
+}
+
+.term-ls-title {
+  color: var(--t-dim);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.term-ls-meta {
+  color: var(--t-dim);
+  font-size: 12px;
+  white-space: nowrap;
+}
+
+.term-ls-footer {
+  display: inline-block;
+  margin-top: 4px;
+  color: var(--t-dim);
+  text-decoration-color: var(--t-dim);
+}
+
+/* --- help / completions / neofetch ------------------------------------------- */
+
+.term-help p {
+  display: grid;
+  grid-template-columns: 20ch minmax(0, 1fr);
+  gap: 0 12px;
+}
+
+.term-help-cmd {
+  color: var(--t-amber);
+}
+
+.term-help .term-hint {
+  display: block;
+  margin-top: 8px;
+}
+
+.term-completions {
+  white-space: pre-wrap;
+}
+
+.term-neofetch {
+  display: flex;
+  gap: 28px;
+  align-items: center;
+  flex-wrap: wrap;
+  padding: 6px 0;
+}
+
+.term-neofetch-art {
+  font-family: var(--font-mono);
+  font-size: 12px;
+  line-height: 1.35;
+  color: var(--t-ok);
+  margin: 0;
+}
+
+.term-neofetch-info p {
+  white-space: pre-wrap;
+}
+
+.term-neofetch-key {
+  color: var(--t-amber);
+  font-weight: 500;
+}
+
+.term-neofetch-palette {
+  display: inline-flex;
+  gap: 4px;
+  margin-top: 8px;
+}
+
+.term-neofetch-palette span {
+  width: 14px;
+  height: 14px;
+  border-radius: 3px;
+}
+
+/* --- Live prompt line -------------------------------------------------------- */
+
+.term-live {
+  position: relative;
+  color: var(--t-strong);
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+}
+
+.term-mirror {
+  color: var(--t-strong);
+}
+
+.term-cursor {
+  display: inline-block;
+  min-width: 1ch;
+  white-space: pre;
+  border-radius: 1px;
+  color: var(--t-text);
+  box-shadow: inset 0 0 0 1px var(--t-dim);
+}
+
+.term-live.focused .term-cursor {
+  background: var(--t-text);
+  color: var(--t-bg);
+  box-shadow: none;
+  animation: term-blink 1.1s step-end infinite;
+}
+
+@keyframes term-blink {
+  50% {
+    background: transparent;
+    color: var(--t-text);
+  }
+}
+
+.term-placeholder {
+  color: var(--t-dim);
+  font-style: italic;
+  user-select: none;
+}
+
+/* Real focusable input, visually absorbed by the mirror. Kept at 16px so iOS
+ * does not zoom the page when it focuses. */
+.term-input {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  border: none;
+  padding: 0;
+  background: transparent;
+  color: transparent;
+  caret-color: transparent;
+  font-size: 16px;
+  outline: none;
+  pointer-events: none;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .term-live.focused .term-cursor {
+    animation: none;
+  }
+}
+
+@media (max-width: 560px) {
+  .term-body {
+    padding: 14px 12px 16px;
+    font-size: 12.5px;
+  }
+
+  .term-ls-row {
+    grid-template-columns: minmax(0, 1fr) auto;
+  }
+
+  .term-ls-title {
+    display: none;
+  }
+
+  .term-neofetch {
+    gap: 16px;
+  }
+
+  .term-neofetch-art {
+    font-size: 9px;
+  }
+}


### PR DESCRIPTION
## What

Turns the home page into a two-column layout (desktop ≥1024px): hero + an interactive zsh-flavoured terminal on the left, featured articles/projects on the right. Mobile keeps the familiar stacking: hero → terminal → featured. An ASCII cat now keeps the intro paragraph company.

## The terminal

- Boots with a `neofetch` card and a `try 'help'` prompt; scrolls inside its own window (the page never moves).
- Commands: `help`, `ls` (`-a`, `-l`), `cd`, `pwd`, `cat`, `open`, `echo`, `whoami`, `history`, `theme dark|light`, `neofetch`/`fastfetch`, `clear`, `exit`, plus a few easter eggs (`sudo`, `vim`, …).
- Virtual filesystem built entirely from API data (site config, about, featured posts, slug totals) — nothing content-bearing is hardcoded; only persona jokes are.
- zsh-authentic UX: tab completion (longest-common-prefix + ambiguous listing), ↑/↓ history with draft preservation, `Ctrl+C`/`Ctrl+L`, block cursor.
- Light and dark theme variants, driven by the site's existing tokens.

## Implementation notes

- Command logic is a pure, serializable interpreter (`commands.ts`) separate from the React component — unit-tested without a DOM (25 new tests, 37 total passing).
- Boot transcript is a pure function of server props (uptime precomputed server-side) so SSR and hydration always agree.
- The input is uncontrolled (DOM owns the value) so programmatic writes — password managers, IME, test drivers — can never desync it.
- SEO unchanged: hero `<h1>` and all featured links remain server-rendered.
- `aria-live` log, `prefers-reduced-motion` honored, 16px input to avoid iOS zoom.

## Testing

- `vitest`: 37/37, `tsc --noEmit` clean, prettier clean.
- Verified in-browser via Playwright MCP across dark/light/mobile: command I/O, completion, history, theme switching, scroll containment, zero console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)