### PR TITLE
Fix runtime cache permissions, feed metadata, and the doubled About title

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,9 +25,15 @@ RUN apt-get update \
   && apt-get install -y --no-install-recommends curl \
   && rm -rf /var/lib/apt/lists/*
 
-COPY --from=build /app/.next/standalone ./
-COPY --from=build /app/.next/static ./.next/static
-COPY --from=build /app/public ./public
+COPY --from=build --chown=node:node /app/.next/standalone ./
+COPY --from=build --chown=node:node /app/.next/static ./.next/static
+COPY --from=build --chown=node:node /app/public ./public
+
+# The server writes rendered pages and fetch-cache entries under .next/cache at
+# runtime. Copied files land root-owned, so without this the unprivileged user
+# gets EACCES on every write and the whole data cache silently degrades to
+# fetching upstream on every request.
+RUN mkdir -p .next/cache && chown -R node:node .next
 
 USER node
 EXPOSE 3000

--- a/src/app/(site)/about/page.tsx
+++ b/src/app/(site)/about/page.tsx
@@ -7,7 +7,9 @@ import '@/styles/about.css';
 export async function generateMetadata(): Promise<Metadata> {
   const about = await getAbout();
   return {
-    title: about.seoTitle ?? `About — ${about.fullName}`,
+    // The site layout's title template already appends the name, so this is
+    // the page part only — 'About — <name>' here rendered it twice.
+    title: about.seoTitle ?? 'About',
     description: about.seoDescription ?? undefined,
   };
 }

--- a/src/app/rss.xml/route.ts
+++ b/src/app/rss.xml/route.ts
@@ -1,4 +1,4 @@
-import { getPosts } from '@/lib/api';
+import { getPosts, getSiteConfig } from '@/lib/api';
 import { siteUrl } from '@/lib/seo';
 
 const escapeXml = (value: string): string =>
@@ -20,7 +20,7 @@ const escapeXml = (value: string): string =>
 export async function GET() {
   const base = siteUrl();
   // The blog feed covers articles; projects are portfolio items, not feed posts.
-  const { items } = await getPosts('article', 1, 50);
+  const [{ items }, config] = await Promise.all([getPosts('article', 1, 50), getSiteConfig()]);
 
   const entries = items
     .map((post) => {
@@ -44,9 +44,9 @@ export async function GET() {
   const xml = `<?xml version="1.0" encoding="UTF-8"?>
 <rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
   <channel>
-    <title>Mikhail Bahdashych — Blog</title>
+    <title>${escapeXml(config.seoDefaultTitle)}</title>
     <link>${base}</link>
-    <description>Security engineering notes: detection engineering, cloud security, write-ups.</description>
+    <description>${escapeXml(config.seoDefaultDescription)}</description>
     <language>en</language>
     <atom:link href="${base}/rss.xml" rel="self" type="application/rss+xml" />
 ${entries}


### PR DESCRIPTION
Three defects found while seeding and verifying production content.

### 1. `.next/cache` was unwritable in production (the real one)
The runtime stage copies build output as root, then switches to `USER node`. Every prerender/fetch-cache write failed:
```
Failed to update prerender cache … [Error: EACCES: permission denied, mkdir '/app/.next/cache']
```
So the tag-based data cache never persisted and **every request re-fetched the API** — the caching the README describes was silently not happening. Fixed with `--chown=node:node` on the copies plus a pre-created cache directory.

Verified by building this image and running it: **0 EACCES lines**, `.next/cache` owned by `node`, and `fetch-cache/` populating on request.

### 2. RSS channel metadata was hardcoded
Feed title/description ignored the SEO copy set in the admin panel — the feed still advertised placeholder text after production was seeded. Both now read from site config (XML-escaped like the rest of the feed).

### 3. Doubled About title
`About — ${fullName}` plus the layout's `%s · Mikhail Bahdashych` template rendered **"About — Mikhail Bahdashych · Mikhail Bahdashych"**. The page part is now just `About`, matching how post titles work.

`npm run typecheck` clean, 41/41 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)