### PR TITLE
About page layout, justified copy, aligned status art, and per-page canonicals

### DIFF
--- a/src/app/(site)/about/page.tsx
+++ b/src/app/(site)/about/page.tsx
@@ -11,6 +11,9 @@ export async function generateMetadata(): Promise<Metadata> {
     // the page part only — 'About — <name>' here rendered it twice.
     title: about.seoTitle ?? 'About',
     description: about.seoDescription ?? undefined,
+    // Without this the page inherits the layout's canonical ('/') and tells
+    // search engines it is a duplicate of the home page.
+    alternates: { canonical: '/about' },
   };
 }
 
@@ -30,6 +33,8 @@ export default async function AboutPage() {
 
   return (
     <>
+      {/* Avatar and greeting share a row; the profile runs full width beneath
+          it, which keeps the text column readable down to phone widths. */}
       <div className="about-head">
         <span className="avatar">
           {about.avatarUrl ? (
@@ -38,11 +43,10 @@ export default async function AboutPage() {
             initials(about.fullName)
           )}
         </span>
-        <div className="about-intro">
-          <h1 className="about-h1">Hi, I&apos;m {firstName}.</h1>
-          <div className="about-lede" dangerouslySetInnerHTML={{ __html: profile.html }} />
-        </div>
+        <h1 className="about-h1">Hello, World! I&apos;m {firstName} 👋</h1>
       </div>
+
+      <div className="about-lede" dangerouslySetInnerHTML={{ __html: profile.html }} />
 
       <div className="contact-line">
         <span className="contact-muted">{about.location}</span>

--- a/src/app/(site)/blog/page.tsx
+++ b/src/app/(site)/blog/page.tsx
@@ -5,6 +5,9 @@ export const metadata: Metadata = {
   title: 'Blog',
   description:
     'Security engineering write-ups: detection engineering, cloud security, incident notes.',
+  // Without this the page inherits the layout's canonical ('/') and tells
+  // search engines it is a duplicate of the home page.
+  alternates: { canonical: '/blog' },
 };
 
 interface Props {

--- a/src/app/(site)/projects/page.tsx
+++ b/src/app/(site)/projects/page.tsx
@@ -4,6 +4,9 @@ import { Listing, parseListingParams } from '@/components/listing';
 export const metadata: Metadata = {
   title: 'Projects',
   description: 'Security tooling and infrastructure projects.',
+  // Without this the page inherits the layout's canonical ('/') and tells
+  // search engines it is a duplicate of the home page.
+  alternates: { canonical: '/projects' },
 };
 
 interface Props {

--- a/src/styles/about.css
+++ b/src/styles/about.css
@@ -3,9 +3,8 @@
 .about-head {
   margin-top: 52px;
   display: flex;
-  gap: 28px;
-  align-items: flex-start;
-  flex-wrap: wrap;
+  gap: 22px;
+  align-items: center;
 }
 
 .avatar {
@@ -30,25 +29,31 @@
   object-fit: cover;
 }
 
-.about-intro {
-  flex: 1;
-  min-width: 300px;
-}
-
 .about-h1 {
   font-family: var(--font-serif);
   font-size: 28px;
   font-weight: 600;
   line-height: 1.3;
   color: var(--text);
+  text-wrap: balance;
 }
 
 .about-lede {
-  margin-top: 14px;
+  margin-top: 22px;
   font-family: var(--font-serif);
   font-size: 16px;
   line-height: 1.75;
   color: var(--body);
+  text-align: justify;
+  /* Justification without hyphenation opens rivers of whitespace once the
+     column narrows, so the two travel together everywhere on this page. */
+  -webkit-hyphens: auto;
+  hyphens: auto;
+}
+
+/* Markdown renders one <p> per paragraph; space them like article prose. */
+.about-lede > * + * {
+  margin-top: 20px;
 }
 
 .about-lede a {
@@ -229,6 +234,9 @@
   font-size: 13px;
   line-height: 1.6;
   color: var(--muted);
+  text-align: justify;
+  -webkit-hyphens: auto;
+  hyphens: auto;
 }
 
 .edu-notes {
@@ -237,6 +245,9 @@
   font-size: 13px;
   line-height: 1.6;
   color: var(--secondary);
+  text-align: justify;
+  -webkit-hyphens: auto;
+  hyphens: auto;
 }
 
 .entry-bullets {
@@ -249,6 +260,9 @@
   font-size: 13.5px;
   line-height: 1.65;
   color: var(--body);
+  text-align: justify;
+  -webkit-hyphens: auto;
+  hyphens: auto;
 }
 
 .entry-bullets li + li {
@@ -278,8 +292,21 @@
     grid-template-columns: 1fr;
   }
 
+  /* Keep the avatar and greeting on one line: a full-size avatar leaves the
+     heading too little room and it used to wrap onto its own row entirely. */
   .about-head {
     margin-top: 40px;
+    gap: 16px;
+  }
+
+  .avatar {
+    width: 64px;
+    height: 64px;
+    font-size: 18px;
+  }
+
+  .about-h1 {
+    font-size: 22px;
   }
 }
 
@@ -344,6 +371,9 @@
   font-size: 12.5px;
   line-height: 1.6;
   color: var(--secondary);
+  text-align: justify;
+  -webkit-hyphens: auto;
+  hyphens: auto;
 }
 
 .cert-foot {

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -413,6 +413,10 @@ h3 {
   color: var(--secondary);
   white-space: pre;
   user-select: none;
+  /* The page centers its children, and a centered <pre> centers each line
+     independently — which pulls the cat's ears off its face. The box is still
+     centered as a flex item; only the lines inside it align left. */
+  text-align: left;
 }
 
 .status-code {


### PR DESCRIPTION
### ASCII cats on 404 / maintenance
`.status-page` centers its children, so the centered `<pre>` centered **each line independently** and the cat came apart. `.status-art` now aligns its lines left while the block itself stays centered.

Verified by measuring rendered line boxes on both pages: all three lines share one left edge, block still centered on the page.

### About page
- **Avatar + greeting now share one row, profile runs full width below.** Previously `.about-intro` had `min-width: 300px` inside a wrapping flex row, so on phones it wrapped and left the avatar sitting alone on its own line. Measured at 390px: avatar and heading on one row, profile full width beneath. Desktop benefits too — the text column went from ~480px to the full 668px.
- Greeting is now **"Hello, World! I'm Mikhail 👋"** (name still comes from the API).
- **Justified copy** across the page: profile, role descriptions, bullets, education notes and certificate descriptions — each paired with `hyphens: auto`, since justification without hyphenation opens rivers of whitespace in the narrow bullet and certificate columns.
- **Paragraph spacing** in the profile: markdown paragraphs ran together; they now use the same `> * + *` spacing rhythm as article prose.
- Smaller avatar and heading under 560px so the row holds together.

### Per-page canonicals (SEO bug)
`baseMetadata` sets `alternates: { canonical: '/' }`, and only post detail pages overrode it — so **/about, /blog and /projects each advertised the home page as their canonical URL**, which can keep them out of search results entirely. Each now declares its own.

`npm run typecheck` clean, 41/41 tests pass, Prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)