### PR TITLE
Serve maintenance mode as 503 instead of redirecting

### DIFF
--- a/src/app/maintenance/page.tsx
+++ b/src/app/maintenance/page.tsx
@@ -6,9 +6,19 @@ import type { Metadata } from 'next';
  * purpose: it must render with zero API involvement — see the root layout.
  */
 
+/**
+ * This page declares no robots directive of its own. Its markup is served by
+ * the middleware at whatever URL was requested, so anything set here would be
+ * attached to real content URLs like /blog rather than to this page.
+ *
+ * Nothing is lost by leaving it off: Next emits `noindex` automatically on any
+ * response above 400, and search engines act on the 503 itself — a temporary
+ * status they retry — not on the body of an error response. The middleware
+ * guarantees this page is never served with a 200; with the flag off,
+ * /maintenance redirects home.
+ */
 export const metadata: Metadata = {
   title: { absolute: 'Back soon · Mikhail Bahdashych' },
-  robots: { index: false },
 };
 
 /** The resident, off duty. */

--- a/src/lib/maintenance.test.ts
+++ b/src/lib/maintenance.test.ts
@@ -1,24 +1,30 @@
 import { describe, expect, it } from 'vitest';
-import { maintenanceRedirect } from './maintenance';
+import { maintenanceAction } from './maintenance';
 
-describe('maintenanceRedirect', () => {
-  it('sends every page to /maintenance while enabled', () => {
-    expect(maintenanceRedirect('/', true)).toBe('/maintenance');
-    expect(maintenanceRedirect('/blog', true)).toBe('/maintenance');
-    expect(maintenanceRedirect('/blog/some-post', true)).toBe('/maintenance');
-    expect(maintenanceRedirect('/no-such-page', true)).toBe('/maintenance');
+describe('maintenanceAction', () => {
+  it('marks every page unavailable while enabled', () => {
+    expect(maintenanceAction('/', true)).toEqual({ kind: 'unavailable' });
+    expect(maintenanceAction('/blog', true)).toEqual({ kind: 'unavailable' });
+    expect(maintenanceAction('/blog/some-post', true)).toEqual({ kind: 'unavailable' });
+    expect(maintenanceAction('/no-such-page', true)).toEqual({ kind: 'unavailable' });
   });
 
-  it('leaves /maintenance alone while enabled', () => {
-    expect(maintenanceRedirect('/maintenance', true)).toBeNull();
+  it('serves the holding page in place rather than redirecting to it', () => {
+    // A redirect would teach crawlers that the real URL moved; the outage has
+    // to be reported at the URL that was asked for.
+    expect(maintenanceAction('/blog/some-post', true)).not.toHaveProperty('to');
+  });
+
+  it('reports /maintenance itself as unavailable too', () => {
+    expect(maintenanceAction('/maintenance', true)).toEqual({ kind: 'unavailable' });
   });
 
   it('lets normal traffic through when disabled', () => {
-    expect(maintenanceRedirect('/', false)).toBeNull();
-    expect(maintenanceRedirect('/blog/some-post', false)).toBeNull();
+    expect(maintenanceAction('/', false)).toBeNull();
+    expect(maintenanceAction('/blog/some-post', false)).toBeNull();
   });
 
-  it('sends /maintenance visitors home when disabled', () => {
-    expect(maintenanceRedirect('/maintenance', false)).toBe('/');
+  it('sends stale /maintenance visitors home when disabled', () => {
+    expect(maintenanceAction('/maintenance', false)).toEqual({ kind: 'redirect', to: '/' });
   });
 });

--- a/src/lib/maintenance.ts
+++ b/src/lib/maintenance.ts
@@ -1,16 +1,24 @@
 /**
- * Where a request should be redirected given the maintenance flag, or null to
- * let it through. Pure so the middleware's routing decision is unit-testable:
- * maintenance on sends every page to /maintenance; maintenance off sends
- * anyone still parked on /maintenance back home.
+ * What to do with a request given the maintenance flag. Pure so the
+ * middleware's routing decision is unit-testable.
+ *
+ * While maintenance is on, every page — including /maintenance itself — is
+ * served as "temporarily unavailable" at the URL that was asked for. It is
+ * deliberately not a redirect: a search engine following one to a holding page
+ * learns that the real URL moved, and pages start dropping out of the index if
+ * the outage lasts. A 503 at the original URL says "come back later" instead,
+ * which is exactly what this is.
+ *
+ * With the flag off, anyone still parked on /maintenance is sent home.
  */
-export function maintenanceRedirect(pathname: string, enabled: boolean): string | null {
-  const onMaintenancePage = pathname === '/maintenance';
-  if (enabled && !onMaintenancePage) {
-    return '/maintenance';
+export type MaintenanceAction = { kind: 'unavailable' } | { kind: 'redirect'; to: string } | null;
+
+export function maintenanceAction(pathname: string, enabled: boolean): MaintenanceAction {
+  if (enabled) {
+    return { kind: 'unavailable' };
   }
-  if (!enabled && onMaintenancePage) {
-    return '/';
+  if (pathname === '/maintenance') {
+    return { kind: 'redirect', to: '/' };
   }
   return null;
 }

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from 'next/server';
 import type { NextRequest } from 'next/server';
-import { maintenanceRedirect } from '@/lib/maintenance';
+import { maintenanceAction } from '@/lib/maintenance';
 
 /**
  * Maintenance gate. Every page request asks the API for the flag — uncached
@@ -36,7 +36,29 @@ async function maintenanceEnabled(): Promise<boolean> {
   }
 }
 
+/**
+ * How long crawlers (and browsers) are told to wait before retrying. A deploy
+ * takes a couple of minutes; an hour is a safe upper bound that keeps search
+ * engines from hammering the origin, and it costs nothing when the flag is
+ * flipped back sooner — the very next request is served normally.
+ */
+const RETRY_AFTER_SECONDS = 3600;
+
 export async function middleware(request: NextRequest) {
-  const target = maintenanceRedirect(request.nextUrl.pathname, await maintenanceEnabled());
-  return target ? NextResponse.redirect(new URL(target, request.url)) : NextResponse.next();
+  const action = maintenanceAction(request.nextUrl.pathname, await maintenanceEnabled());
+
+  if (!action) {
+    return NextResponse.next();
+  }
+  if (action.kind === 'redirect') {
+    return NextResponse.redirect(new URL(action.to, request.url));
+  }
+
+  // Serve the holding page's markup at whatever URL was requested, under a 503
+  // rather than a redirect, so the address stays put and search engines treat
+  // the outage as temporary. See lib/maintenance.ts.
+  return NextResponse.rewrite(new URL('/maintenance', request.url), {
+    status: 503,
+    headers: { 'Retry-After': String(RETRY_AFTER_SECONDS) },
+  });
 }


### PR DESCRIPTION
Follow-up to the SEO audit.

**Before:** every page 307-redirected to `/maintenance`, which rendered with `noindex`. For a short deploy that is harmless, but a redirect tells search engines the URL moved to a holding page — leave the flag on for a day of content work and pages start dropping out of the index.

**After:** the middleware *rewrites* to the holding page and answers **503 with `Retry-After: 3600`**. The requested URL stays in the address bar, and search engines see a temporary status they will retry rather than a move. This is what Google asks for during planned downtime.

`maintenanceRedirect` becomes `maintenanceAction` — the decision is no longer just "where to", since serving in place and sending a stale `/maintenance` visitor home are different actions.

Verified locally against a maintenance-on API:

| URL | status | Retry-After | body |
| --- | --- | --- | --- |
| `/` | 503 | 3600 | holding page |
| `/blog/some-post` | 503 | 3600 | holding page |
| `/maintenance` | 503 | 3600 | holding page |

…and with the flag off: `/` 200, `/about` 200, `/maintenance` → 307 home, unknown URL → 404.

One note for the record: the served markup still contains `<meta name="robots" content="noindex">`, but that is **Next itself** — `NonIndex` in `app-render.js` adds it to any response above 400. It is not something this repo sets, and it does not change the outcome: crawlers act on the 503 status, not on the body of an error response. The page's own `robots: { index: false }` was dropped because its markup is served at arbitrary URLs, where a self-declared directive would apply to real content paths.

`npm run typecheck` clean, 42/42 tests pass, Prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)